### PR TITLE
Reorganised INSDC accession fields

### DIFF
--- a/json_schema/project.json
+++ b/json_schema/project.json
@@ -1,98 +1,99 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "A sample contains information on the biosample that was sequenced or imaged. This includes donor, body part, and anything that comes between removing the sample from a donor and the assay.",    "additionalProperties" : false,
+    "additionalProperties": false,
+    "definitions": {},
+    "description": "project schema generate by tagSchemaToJson from project",
     "patternProperties": {
-       "^characteristics_.*$": {
-            "description": "Fields that begin with characteristics_ can contain any value, and the field name can be anything after the prefix.",
-             "type": "string"
-
-       }
+        "^characteristics_.*$": {
+            "description": "Fields that begin with characteristics_ can contain any value, and the field name can be anything after the prefix",
+            "type": "string"
+        }
     },
-    "allOf" : [{"required" : ["id", "type", "ncbi_taxon_id"]}],
-    "oneOf" : [{"required" : ["donor_description"], "properties": { "type":  { "enum" : ["donor"]}}},
-              {"required" : ["immortalized_cell_line_description"], "properties": { "type":  { "enum" : ["immortalized_cell_line"]}}},
-              {"required" : ["cell_suspension_description"], "properties": { "type":  { "enum" : ["cell_suspension"]}}},
-              {"required" : ["organoid_description"], "properties": { "type":  { "enum" : ["organoid"]}}},
-              {"required" : ["primary_cell_line_description"], "properties": { "type":   { "enum" : ["primary_cell_line"]}}},
-              {"required" : ["specimen_from_organism_description"], "properties": { "type":  { "enum" : ["specimen_from_organism"]}}}
-              ],
-
     "properties": {
-        "core": { "$ref": "core.json" },
-        "type": {
-            "description": "The name of the core metadata entity type.",
-            "enum": [
-                "donor",
-                "specimen_from_organism",
-                "cell_suspension",
-                "organoid",
-                "immortalized_cell_line",
-                "primary_cell_line"
-            ]
-        },
-        "sample_id":{
-            "description": "A local identifier for the sample. Should be unique in the context of the project.",
+        "project_id":{
+            "description": "A unique ID for the project.",
             "type": "string"
         },
         "name": {
-            "description": "A short, descriptive name for the sample that need not be unique.",
+            "description": "A short descriptive name for the entity project. Does not need to be unique.",
             "type": "string"
         },
         "description": {
-            "description": "A general description of the sample.",
+            "description": "A general description of the project.",
             "type": "string"
         },
-        "donor_description" : {
-          "$ref": "donor.json"
+        "array_express_investigation": {
+            "description": "An EBI ArrayExpress investigation accession.",
+            "pattern": "^E-....-.*$",
+            "type": "string"
         },
-        "specimen_from_organism_description" : {
-          "$ref": "specimen_from_organism.json"
+        "contributors": {
+	        "description": "List of people contributing to the project.",
+            "items": {
+                "$ref": "contact.json"
+            },
+            "type": "array"
         },
-         "immortalized_cell_line_description" : {
-          "$ref": "immortalized_cell_line.json"
+        "core": {
+            "$ref": "core.json",
+            "description": "type and schema for this object"
         },
-        "primary_cell_line_description" : {
-          "$ref": "primary_cell_line.json"
+        "experimental_design": {
+            "items": {
+                "$ref": "ontology.json",
+                "description": "A short description of overall experiment type. e.g. \"single cell RNA sequencing.\""
+            },
+            "type": "array"
         },
-        "organoid_description" : {
-          "$ref": "organoid.json"
-        },
-        "cell_suspension_description" : {
-          "$ref": "cell_suspension.json"
-        },
-
-        "ncbi_taxon_id" : {
-          "description": "A taxonomy ID (taxonID) from NCBI.",
-          "type" : "integer"
-        },
-        "genus_species": {
-            "description": "Scientific binomial name of donor species. e.g. \"homo sapiens\". NCBI taxon in ontology field.",
-            "$ref": "ontology.json"
-        },
-        "supplementary_files": {
-            "description": "A list of filenames of sample-level supplementary files.",
+        "experimental_factor_name": {
+            "description": "A list of the factors that vary between samples in the experiment. e.g. \"time since collection\", \"preservation method\"",
             "items": {
                 "type": "string"
             },
             "type": "array"
         },
-        "sample_accessions": {
-            "type": "object",
-            "description": "One or more accession numbers from a standard archive.",
-            "additionalProperties" : false,
-             "properties": {
-                "biosd_sample": {
-                    "description": "A DDBJ, NCBI, or EBI BioSample ID. Accessions must start with SAMD, SAMN, or SAME.",
-                    "pattern": "^SAM[N|E|D]\d+$",
-                    "type": "string"
-                },
-                "insdc_sample": {
-                    "description": "An INSDC (International Nucleotide Sequence Database Collaboration) sample accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRS, ERS, or SRS.",
-                    "pattern": "^[D|E|S]RS\d+$",
-                    "type": "string"
-                }
-            }
+        "geo_series": {
+            "description": "An NCBI GEO series accession.",
+            "pattern": "^GSE.*$",
+            "type": "string"
+        },
+        "insdc_project": {
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) project accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRP, ERP, or SRP.",
+            "pattern": "^[D|E|S]RP\d+$",
+            "type": "string"
+        },
+        "insdc_study": {
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) study accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with PRJE, PRJN, or PRJD",
+            "pattern": "^PRJ[E|N|D]\w\d+$",
+            "type": "string"
+        },
+        "publications": {
+            "items": {
+                "$ref": "publication.json",
+                "description": "An array of publication modules."
+            },
+            "type": "array"
+        },
+        "related_projects": {
+            "description": "A list of other projects that may be logically grouped with this one.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "supplementary_files": {
+            "description": "Project-level supplementary files. e.g. experimental design documents, lab spreadsheets, manuscripts in preparation.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
         }
     },
-    "title": "sample"
+    "required": [
+    	"core",
+	    "contributors",
+        "id"
+    ],
+    "title": "project",
+    "type": "object"
 }

--- a/json_schema/project.json
+++ b/json_schema/project.json
@@ -1,103 +1,98 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false, 
-    "definitions": {}, 
-    "description": "project schema generate by tagSchemaToJson from project", 
+    "description": "A sample contains information on the biosample that was sequenced or imaged. This includes donor, body part, and anything that comes between removing the sample from a donor and the assay.",    "additionalProperties" : false,
     "patternProperties": {
-        "^characteristics_.*$": {
-            "description": "Fields that begin with characteristics_ can contain any value, and the field name can be anything after the prefix",
-            "type": "string"
-        }
-    }, 
+       "^characteristics_.*$": {
+            "description": "Fields that begin with characteristics_ can contain any value, and the field name can be anything after the prefix.",
+             "type": "string"
+
+       }
+    },
+    "allOf" : [{"required" : ["id", "type", "ncbi_taxon_id"]}],
+    "oneOf" : [{"required" : ["donor_description"], "properties": { "type":  { "enum" : ["donor"]}}},
+              {"required" : ["immortalized_cell_line_description"], "properties": { "type":  { "enum" : ["immortalized_cell_line"]}}},
+              {"required" : ["cell_suspension_description"], "properties": { "type":  { "enum" : ["cell_suspension"]}}},
+              {"required" : ["organoid_description"], "properties": { "type":  { "enum" : ["organoid"]}}},
+              {"required" : ["primary_cell_line_description"], "properties": { "type":   { "enum" : ["primary_cell_line"]}}},
+              {"required" : ["specimen_from_organism_description"], "properties": { "type":  { "enum" : ["specimen_from_organism"]}}}
+              ],
+
     "properties": {
-        "project_id":{
-            "description": "A unique ID for the project.",
+        "core": { "$ref": "core.json" },
+        "type": {
+            "description": "The name of the core metadata entity type.",
+            "enum": [
+                "donor",
+                "specimen_from_organism",
+                "cell_suspension",
+                "organoid",
+                "immortalized_cell_line",
+                "primary_cell_line"
+            ]
+        },
+        "sample_id":{
+            "description": "A local identifier for the sample. Should be unique in the context of the project.",
             "type": "string"
         },
         "name": {
-            "description": "A short descriptive name for the entity project. Does not need to be unique.",
+            "description": "A short, descriptive name for the sample that need not be unique.",
             "type": "string"
         },
         "description": {
-            "description": "A general description of the project.",
+            "description": "A general description of the sample.",
             "type": "string"
         },
-        "array_express_investigation": {
-            "description": "An EBI ArrayExpress investigation accession.",
-            "pattern": "^E-....-.*$" 
-        }, 
-        "contributors": {
-	        "description": "List of people contributing to the project.",
-            "items": {
-                "$ref": "contact.json"
-            }, 
-            "type": "array"
-        }, 
-        "core": {
-            "$ref": "core.json", 
-            "description": "type and schema for this object"
-        }, 
-        "ddjb_trace": {
-            "description": "Japanese trace archive project accession.", 
-            "pattern": "^ERP.*$", 
-            "type": "string"
+        "donor_description" : {
+          "$ref": "donor.json"
         },
-        "experimental_design": {
-            "items": {
-                "$ref": "ontology.json",
-                "description": "A short description of overall experiment type. e.g. \"single cell RNA sequencing.\""
-            }, 
-            "type": "array"
-        }, 
-        "experimental_factor_name": {
-            "description": "A list of the factors that vary between samples in the experiment. e.g. \"time since collection\", \"preservation method\"",
-            "items": {
-                "type": "string"
-            }, 
-            "type": "array"
-        }, 
-        "geo_series": {
-            "description": "An NCBI GEO series accession.",
-            "pattern": "^GSE.*$", 
-            "type": "string"
+        "specimen_from_organism_description" : {
+          "$ref": "specimen_from_organism.json"
         },
-        "ncbi_bioproject": {
-            "description": "An NCBI BioProject ID.",
-            "pattern": "^PRJNA.*$", 
-            "type": "string"
+         "immortalized_cell_line_description" : {
+          "$ref": "immortalized_cell_line.json"
         },
-        "publications": {
-            "items": {
-                "$ref": "publication.json",
-                "description": "An array of publication modules."
-            }, 
-            "type": "array"
-        }, 
-        "related_projects": {
-            "description": "A list of other projects that may be logically grouped with this one.",
-            "items": {
-                "type": "string"
-            }, 
-            "type": "array"
-        }, 
-        "sra_project": {
-            "description": "An NCBI SRA project accession.",
-            "pattern": "^SRP.*$", 
-            "type": "string"
-        }, 
+        "primary_cell_line_description" : {
+          "$ref": "primary_cell_line.json"
+        },
+        "organoid_description" : {
+          "$ref": "organoid.json"
+        },
+        "cell_suspension_description" : {
+          "$ref": "cell_suspension.json"
+        },
+
+        "ncbi_taxon_id" : {
+          "description": "A taxonomy ID (taxonID) from NCBI.",
+          "type" : "integer"
+        },
+        "genus_species": {
+            "description": "Scientific binomial name of donor species. e.g. \"homo sapiens\". NCBI taxon in ontology field.",
+            "$ref": "ontology.json"
+        },
         "supplementary_files": {
-            "description": "Project-level supplementary files. e.g. experimental design documents, lab spreadsheets, manuscripts in preparation.",
+            "description": "A list of filenames of sample-level supplementary files.",
             "items": {
                 "type": "string"
-            }, 
+            },
             "type": "array"
+        },
+        "sample_accessions": {
+            "type": "object",
+            "description": "One or more accession numbers from a standard archive.",
+            "additionalProperties" : false,
+             "properties": {
+                "biosd_sample": {
+                    "description": "A DDBJ, NCBI, or EBI BioSample ID. Accessions must start with SAMD, SAMN, or SAME.",
+                    "pattern": "^SAM[N|E|D]\d+$",
+                    "type": "string"
+                },
+                "insdc_sample": {
+                    "description": "An INSDC (International Nucleotide Sequence Database Collaboration) sample accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRS, ERS, or SRS.",
+                    "pattern": "^[D|E|S]RS\d+$",
+                    "type": "string"
+                }
+            }
         }
-    }, 
-    "required": [
-    	"core",
-	    "contributors",
-        "id"
-    ], 
-    "title": "project", 
-    "type": "object"
+    },
+    "title": "sample"
 }

--- a/json_schema/sample.json
+++ b/json_schema/sample.json
@@ -82,21 +82,13 @@
             "additionalProperties" : false,
              "properties": {
                 "biosd_sample": {
-                    "description": "EBI biosample ID",
+                    "description": "A DDBJ, NCBI, or EBI BioSample ID. Accessions must start with SAMD, SAMN, or SAME.",
+                    "pattern": "^SAM[N|E|D]\d+$",
                     "type": "string"
                 },
-                "ncbi_biosample": {
-                    "description": "NCBI biosample ID",
-                    "type": "string"
-                },
-                "geo_sample": {
-                    "description": "NCBI GEO sample accession",
-                    "pattern": "^GSM.*$",
-                    "type": "string"
-                },
-                "ena_sample": {
-                    "description": "European nucleotide archive sample ID",
-                    "pattern": "^ERS.*$",
+                "insdc_sample": {
+                    "description": "An INSDC (International Nucleotide Sequence Database Collaboration) sample accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRS, ERS, or SRS.",
+                    "pattern": "^[D|E|S]RS\d+$",
                     "type": "string"
                 }
             }

--- a/json_schema/seq.json
+++ b/json_schema/seq.json
@@ -39,79 +39,73 @@
     }, 
     "description": "Information about how a sample was sequenced.", 
     "properties": {
-        "ena_experiment": {
-            "description": "European Nucleotide Archive experiment accession", 
-            "pattern": "^ERX.*$", 
+        "insdc_experiment": {
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) experiment accession. Accession must start with DRX, ERX, or SRX.",
+            "pattern": "^[D|E|S]RX\d+$",
             "type": "string"
-        }, 
-        "ena_run": {
-            "description": "European Nucleotide Archive run accession", 
-            "pattern": "^ERR.*$", 
-            "type": "string"
-        }, 
+        },
+        "insdc_run": {
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Accession must start with DRR, ERR, or SRR.",
+            "items": {
+                "pattern": "^[D|E|S]RR\d+$",
+                "type": "string"
+            },
+            "type": "array"
+        },
         "instrument_model": {
-            "description": "Examples: HiSeq 200, Pac Bio SEQuel", 
+            "description": "The model of the sequencer used. e.g. HiSeq 2000, Sequel.",
             "enum": [
-                "Illumina HiSeq 2000", 
-                "Illumina HiSeq 2500", 
-                "Illumina HiSeq 4000", 
-                "Illumina MiSeq", 
-                "Illumina NextSeq 500"
+                "HiSeq 2000",
+                "HiSeq 2500",
+                "HiSeq 4000",
+                "MiSeq",
+                "NextSeq 500",
+                "Sequel"
             ]
-        }, 
+        },
         "instrument_platform": {
-            "description": "Examples: Illumina, Ion Torrent, Pac Bio", 
+            "description": "The sequencing platform used. e.g. Illumina, Ion Torrent, Pacific Biosciences.",
             "enum": [
-                "Illumina"
+                "Illumina",
+                "Ion Torrent",
+                "Pacific Biosciences"
             ]
-        }, 
+        },
         "lanes": {
             "$ref": "#/definitions/lanes"
-        }, 
+        },
         "library_construction": {
-            "description": "How dna sequencing library was prepared from sample or rna library.  Examples: \"Nextera XT\" \"TrueSeq\"", 
+            "description": "How the DNA sequencing library was prepared. e.g. \"Nextera XT\" \"TrueSeq\".",
             "enum": [
-                "Nextera XT", 
-                "TruSeq", 
+                "Nextera XT",
+                "TruSeq",
                 "modified Nextera XT"
             ]
-        }, 
+        },
         "library_protocol": {
-            "description": "DNA sequencing library preparation protocol", 
-            "pattern": "^P-....-.*$", 
+            "description": "DNA sequencing library preparation protocol.",
+            "pattern": "^P-....-.*$",
             "type": "string"
-        }, 
+        },
         "local_machine_name": {
-            "description": "Local lab name for particular machine of given platform and model this was run on.", 
+            "description": "Local name for the particular machine on which the sample was sequenced.",
             "type": "string"
-        }, 
+        },
         "molecule": {
-            "description": "RNA, DNA, or protein, or more specifically \"total RNA,\" \"genomic DNA,\"  etc.", 
+            "description": "Specific type of molecule sequenced. e.g. total RNA, genomic DNA, polyA RNA.",
             "enum": [
-                "RNA", 
-                "polyA RNA", 
-                "total RNA"
+                "RNA",
+                "polyA RNA",
+                "total RNA",
+                "genomic DNA"
             ]
-        }, 
+        },
         "paired_ends": {
-            "description": "Is a paired end sequencing strategy used? Values are yes/no", 
+            "description": "Was a paired-end sequencing strategy used? Must be either yes or no.",
             "type": "boolean"
-        }, 
-        "sra_experiment": {
-            "description": "NCBI Short Read Archive experiment accession (SRX)", 
-            "pattern": "^SRX.*$", 
-            "type": "string"
-        }, 
-        "sra_run": {
-            "description": "NCBI Short Read Archive run accession (SRR)", 
-            "items": {
-                "pattern": "^SRR.*$", 
-                "type": "string"
-            }, 
-            "type": "array"
-        }, 
+        },
         "umi_barcode": {
-            "description": "Information about unique molecular identifier barcode", 
+            "description": "Information about unique molecular identifier (umi) barcode.",
             "$ref": "barcode.json"
         }
     }, 


### PR DESCRIPTION
- In project, sample, and seq JSONs combined DDBJ, NCBI, and ENA accession fields for
  - runs
  - samples
  - experiments
  - projects
  - biosamples
- Fixed minor typos and formatting of the field descriptions
- Fixed formatting for instrument model and platform in seq.json

These changes address issue #48 and comments in v3 metadata feedback doc.