### PR TITLE
Add regex to fields in v4.1.0

### DIFF
--- a/json_schema/donor.json
+++ b/json_schema/donor.json
@@ -5,9 +5,8 @@
     "properties": {
         "age": {
             "description": "Age in age_units. For embryos, measured since fertilization. For all others, measured since birth.",
-            "maximum": 150,
-            "minimum": 0,
-            "type": "number"
+            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "type": "string"
         },
         "age_unit": {
             "description": "The unit in which age is expressed. Must be one of day, week, month, or year.",
@@ -15,7 +14,11 @@
                 "hour",
                 "day",
                 "week",
-                "year"
+                "year",
+                "hours",
+                "days",
+                "weeks",
+                "years"
             ]
         },
         "alcohol_history": {
@@ -55,10 +58,9 @@
             "type": "string"
         },
         "height": {
-            "description": "Height of donor in meters.",
-            "maximum": 10,
-            "minimum": 0,
-            "type": "number"
+            "description": "Height of donor, in meters. Can be a range separated by a hyphen.",
+            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "type": "string"
         },
         "is_living": {
             "description": "Should be yes if donor is living at time of sample donation. Otherwise, should be no.",
@@ -109,10 +111,9 @@
             }
         },
         "weight": {
-            "description": "Weight of donor in kilograms.",
-            "maximum": 1000,
-            "minimum": 0,
-            "type": "number"
+            "description": "Weight of donor, in kilograms. Can be a range separated by a hyphen.",
+            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "type": "string"
         }
     },
     "required": [

--- a/json_schema/donor.json
+++ b/json_schema/donor.json
@@ -5,7 +5,7 @@
     "properties": {
         "age": {
             "description": "Age in age_units. For embryos, measured since fertilization. For all others, measured since birth.",
-            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
             "type": "string"
         },
         "age_unit": {
@@ -59,7 +59,7 @@
         },
         "height": {
             "description": "Height of donor, in meters. Can be a range separated by a hyphen.",
-            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
             "type": "string"
         },
         "is_living": {
@@ -112,7 +112,7 @@
         },
         "weight": {
             "description": "Weight of donor, in kilograms. Can be a range separated by a hyphen.",
-            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
             "type": "string"
         }
     },

--- a/json_schema/donor.json
+++ b/json_schema/donor.json
@@ -5,7 +5,7 @@
     "properties": {
         "age": {
             "description": "Age in age_units. For embryos, measured since fertilization. For all others, measured since birth.",
-            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
             "type": "string"
         },
         "age_unit": {
@@ -59,7 +59,7 @@
         },
         "height": {
             "description": "Height of donor, in meters. Can be a range separated by a hyphen.",
-            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
             "type": "string"
         },
         "is_living": {
@@ -112,7 +112,7 @@
         },
         "weight": {
             "description": "Weight of donor, in kilograms. Can be a range separated by a hyphen.",
-            "pattern": "^\d+\.?\d*-?\d*\.?\d*$",
+            "pattern": "^[0-9]+\.?[0-9]*-?[0-9]*\.?[0-9]*$",
             "type": "string"
         }
     },


### PR DESCRIPTION
Changed the following donor.json fields from number type to string type with a regex to allow for users to enter a number range (e.g. to enter "50-60" for age). The regex is: `^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$`
- donor.height
- donor.weight
- donor.age

Added enum values to "donor.age_unit" as some users entered the plural form of the age units already listed in the enum (e.g. user entered "years" instead of "year")
- hours
- days
- weeks
- years