### PR TITLE
V4.3.0 minor release

### DIFF
--- a/json_schema/analysis.json
+++ b/json_schema/analysis.json
@@ -76,7 +76,7 @@
         "inputs": {
             "items": {
                 "type": {
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/analysis.json#/definitions/parameter"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/analysis.json#/definitions/parameter"
                 }
             }, 
             "type": "array", 
@@ -89,7 +89,7 @@
         "tasks": {
             "items": {
                 "type": {
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/analysis.json#/definitions/task"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/analysis.json#/definitions/task"
                 }
             }, 
             "type": "array", 
@@ -113,7 +113,7 @@
         "outputs": {
             "items": {
                 "type": {
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/analysis.json#/definitions/file"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/analysis.json#/definitions/file"
                 }
             }, 
             "type": "array", 
@@ -133,7 +133,7 @@
         }, 
         "core": {
             "description": "Type and schema for this object.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "analysis_run_type": {
             "enum": [

--- a/json_schema/assay.json
+++ b/json_schema/assay.json
@@ -12,7 +12,7 @@
     "properties": {
         "core": {
             "description": "Type and schema for this object.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "name": {
             "type": "string", 
@@ -20,19 +20,19 @@
         }, 
         "seq": {
             "description": "Information about how a cDNA sample was sequenced.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/seq.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/seq.json"
         }, 
         "rna": {
             "description": "Information about how RNA was converted to cDNA.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/rna.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/rna.json"
         }, 
         "single_cell": {
             "description": "Information on single-cell aspects of an assay.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/single_cell.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/single_cell.json"
         }, 
         "imaging": {
             "description": "Information on image based RNA quantification assays", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/imaging.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/imaging.json"
         }, 
         "assay_id": {
             "type": "string", 

--- a/json_schema/assay_bundle.json
+++ b/json_schema/assay_bundle.json
@@ -10,19 +10,19 @@
                 "content": {
                     "type": "object", 
                     "description": "Assay content", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/assay.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/assay.json"
                 }, 
                 "derivation_protocols": {
                     "items": {
                         "description": "An array of protocols used in derivation of this sample.", 
-                        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/protocol.json"
+                        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/protocol.json"
                     }, 
                     "type": "array"
                 }, 
                 "hca_ingest": {
                     "type": "object", 
                     "description": "core fields added by HCA ingest service", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ingest.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
                 }
             }
         }
@@ -31,6 +31,6 @@
     "type": "array", 
     "description": "A schema for an assay bundle", 
     "items": {
-        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/assay_bundle.json#/definitions/assay_ingest"
+        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/assay_bundle.json#/definitions/assay_ingest"
     }
 }

--- a/json_schema/cell_suspension.json
+++ b/json_schema/cell_suspension.json
@@ -1,15 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#", 
     "title": "cell_suspension", 
-    "description": "Information about the cell suspension derived from the collected or cultured specimen", 
     "properties": {
         "well": {
             "description": "Information about wells in a plate or chip used for single-cell isolation.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/well.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/well.json"
         }, 
         "target_cell_type": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/cell_type_ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/cell_type_ontology.json"
             }, 
             "type": "array", 
             "description": "Cell types present in the suspension."
@@ -22,10 +21,11 @@
         }, 
         "enrichment": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/enrichment.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/enrichment.json"
             }, 
             "type": "array", 
             "description": "How sample was enriched for specific cell type(s)."
         }
-    }
+    }, 
+    "description": "Information about the cell suspension derived from the collected or cultured specimen"
 }

--- a/json_schema/contact.json
+++ b/json_schema/contact.json
@@ -64,7 +64,8 @@
                 "XY", 
                 "FU", 
                 "PR", 
-                "VI"
+                "VI",
+                "Cambridgeshire"
             ], 
             "description": "Name of state, province, canton, or other country subdivision."
         }, 

--- a/json_schema/contact.json
+++ b/json_schema/contact.json
@@ -64,7 +64,7 @@
                 "XY", 
                 "FU", 
                 "PR", 
-                "VI",
+                "VI", 
                 "Cambridgeshire"
             ], 
             "description": "Name of state, province, canton, or other country subdivision."

--- a/json_schema/death.json
+++ b/json_schema/death.json
@@ -11,7 +11,7 @@
     "properties": {
         "cause_of_death": {
             "description": "Cause of death from death report for human donor, from research lab for mouse.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }, 
         "hardy_scale": {
             "minimum": 0, 

--- a/json_schema/donor.json
+++ b/json_schema/donor.json
@@ -38,7 +38,7 @@
                 "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
             }, 
             "type": "array", 
-            "description": "The name of th mouse inbred strain. e.g. C57BL/6."
+            "description": "The name of the mouse inbred strain. e.g. C57BL/6."
         }, 
         "alcohol_history": {
             "type": "string", 

--- a/json_schema/donor.json
+++ b/json_schema/donor.json
@@ -22,7 +22,7 @@
         }, 
         "death": {
             "description": "Information about conditions of death (or info that donor was living at time of collection).", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/death.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/death.json"
         }, 
         "genotype": {
             "type": "string", 
@@ -35,7 +35,7 @@
         }, 
         "strain": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
             }, 
             "type": "array", 
             "description": "The name of the mouse inbred strain. e.g. C57BL/6."
@@ -60,7 +60,7 @@
         }, 
         "disease": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/disease_ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/disease_ontology.json"
             }, 
             "type": "array", 
             "description": "Short description of disease status of individual."
@@ -91,7 +91,7 @@
         }, 
         "ancestry": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
             }, 
             "type": "array", 
             "description": "An array of ontology terms from EMBL-EBI's Ancestry Ontology describing ancestral groups, uncategorised ancestral groups, and population isolates."
@@ -111,14 +111,14 @@
         }, 
         "medication": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
             }, 
             "type": "array", 
             "description": "List of medications the donor was currently taking at time of sample donation."
         }, 
         "development_stage": {
             "description": "More detailed (especially for embryos) version of life_stage. e.g. \"E9\" or \"P17\" for mouse.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }
     }
 }

--- a/json_schema/file.json
+++ b/json_schema/file.json
@@ -10,7 +10,7 @@
     "properties": {
         "core": {
             "description": "Type and schema for this object.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "file_format": {
             "enum": [

--- a/json_schema/immortalized_cell_line.json
+++ b/json_schema/immortalized_cell_line.json
@@ -11,7 +11,7 @@
         }, 
         "cell_type": {
             "description": "What cell type the line was derived from. CLO ontology.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/cell_type_ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/cell_type_ontology.json"
         }, 
         "date_established": {
             "type": "string", 
@@ -24,7 +24,7 @@
         }, 
         "disease": {
             "description": "A disease associated with the cell line. EFO ontology.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/disease_ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/disease_ontology.json"
         }, 
         "passage_number": {
             "minimum": 0, 
@@ -34,7 +34,7 @@
         }, 
         "cell_cycle": {
             "description": "The cell cycle phase, if known.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }, 
         "karyotype": {
             "type": "string", 
@@ -42,7 +42,7 @@
         }, 
         "publication": {
             "description": "The publication in which the cell line creation was cited.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/publication.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/publication.json"
         }
     }
 }

--- a/json_schema/organoid.json
+++ b/json_schema/organoid.json
@@ -1,14 +1,14 @@
 {
+    "title": "organoid", 
+    "$schema": "http://json-schema.org/draft-04/schema#", 
     "required": [
         "model_for_organ"
     ], 
-    "$schema": "http://json-schema.org/draft-04/schema#", 
-    "title": "organoid", 
-    "description": "A description of an organoid sample.", 
     "properties": {
         "model_for_organ": {
             "description": "Organ that this organoid is a model system for.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }
-    }
+    }, 
+    "description": "A description of an organoid sample."
 }

--- a/json_schema/primary_cell_line.json
+++ b/json_schema/primary_cell_line.json
@@ -7,7 +7,7 @@
     "properties": {
         "cell_type": {
             "description": "The cell type that the cell line was derived from. Should be a CLO ontology.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/cell_type_ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/cell_type_ontology.json"
         }, 
         "date_established": {
             "type": "string", 
@@ -16,7 +16,7 @@
         }, 
         "disease": {
             "description": "Free text describing any disease association to the cell type. Should be found in EFO ontology.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/disease_ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/disease_ontology.json"
         }, 
         "passage_number": {
             "minimum": 0, 
@@ -26,7 +26,7 @@
         }, 
         "cell_cycle": {
             "description": "The cell cycle phase if the cell line is synchronized growing cells or the phase is known.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }
     }
 }

--- a/json_schema/project.json
+++ b/json_schema/project.json
@@ -19,7 +19,7 @@
     "properties": {
         "core": {
             "description": "type and schema for this object", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "related_projects": {
             "items": {
@@ -34,21 +34,14 @@
         }, 
         "contributors": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/contact.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/contact.json"
             }, 
             "type": "array", 
             "description": "List of people contributing to the project."
         }, 
-        "experimental_factor_name": {
-            "items": {
-                "type": "string"
-            }, 
-            "type": "array", 
-            "description": "A list of the factors that vary between samples in the experiment. e.g. \"time since collection\", \"preservation method\""
-        }, 
         "submitters": {
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/contact.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/contact.json"
             }, 
             "type": "array", 
             "description": "List of people submitting data to the project."
@@ -73,25 +66,32 @@
         "experimental_design": {
             "items": {
                 "description": "A short description of overall experiment type. e.g. \"single cell RNA sequencing.\"", 
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
             }, 
             "type": "array"
         }, 
         "publications": {
             "items": {
                 "description": "An array of publication modules.", 
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/publication.json"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/publication.json"
             }, 
             "type": "array"
+        }, 
+        "experimental_factor_name": {
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "A list of the factors that vary between samples in the experiment. e.g. \"time since collection\", \"preservation method\""
+        }, 
+        "project_id": {
+            "type": "string", 
+            "description": "A unique ID for this project."
         }, 
         "array_express_investigation": {
             "pattern": "^E-....-.*$", 
             "type": "string", 
             "description": "An EBI ArrayExpress investigation accession."
-        }, 
-        "project_id": {
-            "type": "string", 
-            "description": "A unique ID for this project."
         }, 
         "insdc_study": {
             "pattern": "^PRJ[E|N|D][a-zA-Z][0-9]+$", 

--- a/json_schema/project_bundle.json
+++ b/json_schema/project_bundle.json
@@ -10,12 +10,12 @@
                 "content": {
                     "type": "object", 
                     "description": "Project content", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/project.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/project.json"
                 }, 
                 "hca_ingest": {
                     "type": "object", 
                     "description": "core fields added by HCA ingest service", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ingest.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
                 }
             }
         }
@@ -24,6 +24,6 @@
     "type": "array", 
     "description": "A schema for a project bundle", 
     "items": {
-        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/project_bundle.json#/definitions/project_ingest"
+        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/project_bundle.json#/definitions/project_ingest"
     }
 }

--- a/json_schema/protocol.json
+++ b/json_schema/protocol.json
@@ -13,7 +13,7 @@
     "properties": {
         "core": {
             "description": "type and schema for this object", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "retail_name": {
             "type": "string", 
@@ -38,7 +38,7 @@
         }, 
         "type": {
             "description": "The type of protocol. Ideally an EFO term.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }, 
         "name": {
             "type": "string", 

--- a/json_schema/rna.json
+++ b/json_schema/rna.json
@@ -62,7 +62,9 @@
                 "QUARTZ-Seq", 
                 "10x_v2", 
                 "drop-seq", 
-                "inDrop"
+                "inDrop",
+                "10x",
+                "10X"
             ], 
             "description": "The general approach for sequencing library construction. e.g. Smart-seq, Drop-seq, 10x."
         }

--- a/json_schema/rna.json
+++ b/json_schema/rna.json
@@ -62,8 +62,8 @@
                 "QUARTZ-Seq", 
                 "10x_v2", 
                 "drop-seq", 
-                "inDrop",
-                "10x",
+                "inDrop", 
+                "10x", 
                 "10X"
             ], 
             "description": "The general approach for sequencing library construction. e.g. Smart-seq, Drop-seq, 10x."

--- a/json_schema/sample.json
+++ b/json_schema/sample.json
@@ -66,7 +66,7 @@
                     "description": "An INSDC (International Nucleotide Sequence Database Collaboration) sample accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRS, ERS, or SRS."
                 }, 
                 "biosd_sample": {
-                    "pattern": "^SAM[E|N|D][A|G]?[0-9]+$", 
+                    "pattern": "^SAM(D|N|E([AG]?))[0-9]+$",
                     "type": "string", 
                     "description": "A DDBJ, NCBI, or EBI BioSample ID. Accessions must start with SAMD, SAMN, or SAME."
                 }

--- a/json_schema/sample.json
+++ b/json_schema/sample.json
@@ -53,7 +53,7 @@
     "properties": {
         "core": {
             "description": "Type and schema for this object.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/core.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
         }, 
         "sample_accessions": {
             "additionalProperties": false, 
@@ -66,28 +66,28 @@
                     "description": "An INSDC (International Nucleotide Sequence Database Collaboration) sample accession. Can be from the DDBJ, EMBL-EBI, or NCBI. Accession must start with DRS, ERS, or SRS."
                 }, 
                 "biosd_sample": {
-                    "pattern": "^SAM(D|N|E([AG]?))[0-9]+$",
+                    "pattern": "^SAM(D|N|E([AG]?))[0-9]+$", 
                     "type": "string", 
                     "description": "A DDBJ, NCBI, or EBI BioSample ID. Accessions must start with SAMD, SAMN, or SAME."
                 }
             }
         }, 
         "immortalized_cell_line": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/immortalized_cell_line.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/immortalized_cell_line.json"
         }, 
         "description": {
             "type": "string", 
             "description": "A general description of the sample."
         }, 
         "cell_suspension": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/cell_suspension.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/cell_suspension.json"
         }, 
         "specimen_from_organism": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/specimen_from_organism.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/specimen_from_organism.json"
         }, 
         "genus_species": {
             "description": "Scientific binomial name of donor species. e.g. Homo sapiens.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }, 
         "supplementary_files": {
             "items": {
@@ -110,13 +110,13 @@
             "description": "A unique ID for this sample."
         }, 
         "donor": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/donor.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/donor.json"
         }, 
         "primary_cell_line": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/primary_cell_line.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/primary_cell_line.json"
         }, 
         "organoid": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/organoid.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/organoid.json"
         }, 
         "name": {
             "type": "string", 

--- a/json_schema/sample_bundle.json
+++ b/json_schema/sample_bundle.json
@@ -10,19 +10,19 @@
                 "content": {
                     "type": "object", 
                     "description": "Sample content", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/sample.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/sample.json"
                 }, 
                 "derivation_protocols": {
                     "items": {
                         "description": "An array of protocols used in derivation of this sample.", 
-                        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/protocol.json"
+                        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/protocol.json"
                     }, 
                     "type": "array"
                 }, 
                 "hca_ingest": {
                     "type": "object", 
                     "description": "core fields added by HCA ingest service", 
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ingest.json"
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
                 }, 
                 "derived_from": {
                     "type": "string"
@@ -34,6 +34,6 @@
     "type": "array", 
     "description": "A schema for a sample bundle", 
     "items": {
-        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/sample_bundle.json#/definitions/sample_ingest"
+        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/sample_bundle.json#/definitions/sample_ingest"
     }
 }

--- a/json_schema/seq.json
+++ b/json_schema/seq.json
@@ -53,11 +53,7 @@
             "description": "Was a paired-end sequencing strategy used? Must be either yes or no."
         }, 
         "lanes": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/seq.json#/definitions/lanes"
-        }, 
-        "umi_barcode": {
-            "description": "Information about unique molecular identifier (UMI) barcode sequences.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/barcode.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/seq.json#/definitions/lanes"
         }, 
         "insdc_run": {
             "items": {
@@ -90,13 +86,9 @@
             ], 
             "description": "The model of the sequencer used. e.g. HiSeq 2000, Sequel."
         }, 
-        "instrument_platform": {
-            "enum": [
-                "Illumina", 
-                "Ion Torrent", 
-                "Pacific Biosciences"
-            ], 
-            "description": "The sequencing platform used. e.g. Illumina, Ion Torrent, Pacific Biosciences."
+        "umi_barcode": {
+            "description": "Information about unique molecular identifier (UMI) barcode sequences.", 
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/barcode.json"
         }, 
         "library_protocol": {
             "pattern": "^P-....-.*$", 
@@ -108,12 +100,20 @@
             "type": "string", 
             "description": "An INSDC (International Nucleotide Sequence Database Collaboration) experiment accession. Accession must start with DRX, ERX, or SRX."
         }, 
+        "instrument_platform": {
+            "enum": [
+                "Illumina", 
+                "Ion Torrent", 
+                "Pacific Biosciences"
+            ], 
+            "description": "The sequencing platform used. e.g. Illumina, Ion Torrent, Pacific Biosciences."
+        }, 
         "library_construction": {
             "enum": [
                 "Nextera XT", 
                 "TruSeq", 
-                "modified Nextera XT",
-                "10X",
+                "modified Nextera XT", 
+                "10X", 
                 "10x"
             ], 
             "description": "How the DNA sequencing library was prepared. e.g. Nextera XT, TrueSeq."

--- a/json_schema/seq.json
+++ b/json_schema/seq.json
@@ -112,7 +112,9 @@
             "enum": [
                 "Nextera XT", 
                 "TruSeq", 
-                "modified Nextera XT"
+                "modified Nextera XT",
+                "10X",
+                "10x"
             ], 
             "description": "How the DNA sequencing library was prepared. e.g. Nextera XT, TrueSeq."
         }

--- a/json_schema/single_cell.json
+++ b/json_schema/single_cell.json
@@ -20,7 +20,9 @@
                 "drop-seq", 
                 "inDrop", 
                 "mouth pipette", 
-                "bulk"
+                "bulk",
+                "10x",
+                "10X"
             ], 
             "description": "How cells are separated. e.g. FACS, drop-seq, 10X_v2, Fluidigm C1."
         }

--- a/json_schema/single_cell.json
+++ b/json_schema/single_cell.json
@@ -10,7 +10,7 @@
     "properties": {
         "cell_barcode": {
             "description": "Information about cell identifier barcode.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/barcode.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/barcode.json"
         }, 
         "cell_handling": {
             "enum": [
@@ -20,8 +20,8 @@
                 "drop-seq", 
                 "inDrop", 
                 "mouth pipette", 
-                "bulk",
-                "10x",
+                "bulk", 
+                "10x", 
                 "10X"
             ], 
             "description": "How cells are separated. e.g. FACS, drop-seq, 10X_v2, Fluidigm C1."

--- a/json_schema/specimen_from_organism.json
+++ b/json_schema/specimen_from_organism.json
@@ -11,15 +11,15 @@
     "properties": {
         "body_part": {
             "description": "A more detailed position within the body than the term given in the organ field.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology_json/body_part_ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology_json/body_part_ontology.json"
         }, 
         "state_of_specimen": {
             "description": "State of body_part at collection and how it was preserved after removal.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/state_of_specimen.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/state_of_specimen.json"
         }, 
         "organ": {
             "description": "The organ that the sample came from. e.g. liver, spleen. Blood and connective tissue count as organs.", 
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/ontology.json"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ontology.json"
         }
     }
 }

--- a/json_schema/state_of_specimen.json
+++ b/json_schema/state_of_specimen.json
@@ -10,7 +10,7 @@
             "minimum": 0, 
             "type": "integer", 
             "description": "Duration of time, in seconds, that the body part had insufficient blood supply.", 
-            "maximum": 100000
+            "maximum": 1000000
         }, 
         "gross_image": {
             "items": {
@@ -24,7 +24,7 @@
             "minimum": 0, 
             "type": "integer", 
             "description": "Duration of time, in seconds, between when death is declared and when the tissue is preserved or processed.", 
-            "maximum": 100000
+            "maximum": 1000000
         }, 
         "gross_description": {
             "type": "string", 

--- a/json_schema/submission.json
+++ b/json_schema/submission.json
@@ -9,7 +9,7 @@
         "submitted_files": {
             "additionalProperties": false, 
             "items": {
-                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/submission.json#/definitions/file"
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/submission.json#/definitions/file"
             }, 
             "type": "array"
         }, 
@@ -28,10 +28,6 @@
             ], 
             "type": "object", 
             "properties": {
-                "id": {
-                    "type": "string", 
-                    "description": "URI of the Data Storage System file resource that describes this file"
-                }, 
                 "checksums": {
                     "required": [
                         "s3etag", 
@@ -63,6 +59,10 @@
                     "type": "string", 
                     "description": "Name of the file"
                 }, 
+                "id": {
+                    "type": "string", 
+                    "description": "URI of the Data Storage System file resource that describes this file"
+                }, 
                 "content_type": {
                     "type": "string", 
                     "description": "type of file e.g hca-sample-json, hca-assay-json, hca-rnaseq-fastq-gz"
@@ -78,10 +78,10 @@
     "type": "object", 
     "properties": {
         "submitted_files": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/submission.json#/definitions/submitted_files"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/submission.json#/definitions/submitted_files"
         }, 
         "transfer_service_version": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.2.0/json_schema/submission.json#/definitions/transfer_service_version"
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/submission.json#/definitions/transfer_service_version"
         }
     }
 }


### PR DESCRIPTION
Minor release v4.3.0 include the following changes:
1. Increased max state_of_specimen.ischemic_time and state_of_specimen.postmortem_interval value to 1000000 (#89)
1. Added "10X" and "10x" as options to seq.library_construction, rna.library_construction, and single_cell.cell_handling
1. Updated sample.biosd_sample regex to `^SAM(D|N|E([AG]?))[0-9]+$` (#78)
1. Added "Cambridgeshire" to list of accepted enum values for contact.country_division
1. Updated all URLs to reference 4.3.0

**All changes maintain backwards compatibility.**