### PR TITLE
Assay/project_bundle.json now objects. Bundle JSONs have core field.

### DIFF
--- a/json_schema/assay_bundle.json
+++ b/json_schema/assay_bundle.json
@@ -3,7 +3,8 @@
         "assay_ingest": {
             "required": [
                 "hca_ingest", 
-                "content"
+                "content",
+                "core"
             ], 
             "type": "object", 
             "properties": {
@@ -23,14 +24,16 @@
                     "type": "object", 
                     "description": "core fields added by HCA ingest service", 
                     "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
+                },
+                "core": {
+                    "description": "Type and schema for this object.",
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
                 }
             }
         }
     }, 
     "$schema": "http://json-schema.org/draft-04/schema#", 
-    "type": "array", 
+    "type": "object",
     "description": "A schema for an assay bundle", 
-    "items": {
-        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/assay_bundle.json#/definitions/assay_ingest"
-    }
+    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/assay_bundle.json#/definitions/assay_ingest"
 }

--- a/json_schema/core.json
+++ b/json_schema/core.json
@@ -12,7 +12,10 @@
                 "protocol", 
                 "sample", 
                 "file", 
-                "analysis"
+                "analysis",
+                "assay_bundle",
+                "sample_bundle",
+                "project_bundle"
             ], 
             "description": "The name of the core metadata entity type."
         }, 

--- a/json_schema/project_bundle.json
+++ b/json_schema/project_bundle.json
@@ -3,7 +3,8 @@
         "project_ingest": {
             "required": [
                 "hca_ingest", 
-                "content"
+                "content",
+                "core"
             ], 
             "type": "object", 
             "properties": {
@@ -16,14 +17,16 @@
                     "type": "object", 
                     "description": "core fields added by HCA ingest service", 
                     "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
+                },
+                "core": {
+                    "description": "Type and schema for this object.",
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
                 }
             }
         }
     }, 
     "$schema": "http://json-schema.org/draft-04/schema#", 
-    "type": "array", 
-    "description": "A schema for a project bundle", 
-    "items": {
-        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/project_bundle.json#/definitions/project_ingest"
-    }
+    "type": "object",
+    "description": "A schema for a project bundle",
+    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/project_bundle.json#/definitions/project_ingest"
 }

--- a/json_schema/sample_bundle.json
+++ b/json_schema/sample_bundle.json
@@ -3,7 +3,8 @@
         "sample_ingest": {
             "required": [
                 "hca_ingest", 
-                "content"
+                "content",
+                "core"
             ], 
             "type": "object", 
             "properties": {
@@ -25,7 +26,12 @@
                     "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/ingest.json"
                 }, 
                 "derived_from": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The sample that this sample was derived from."
+                },
+                "core": {
+                    "description": "Type and schema for this object.",
+                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.3.0/json_schema/core.json"
                 }
             }
         }


### PR DESCRIPTION
- Updated assay_bundle.json and project_bundle.json to be objects instead of arrays
- Added "core" field to assay_bundle.json, project_bundle.json, and sample_bundle.json to inherit type and schema version/URL
 - Made core fields required
 - Added bundle schemas to list of accepted core types
 - Added description to "derived_from" field in sample_bundle.json