### PR TITLE
Created a new strain_ontology module for mouse strains and referenced…

### DIFF
--- a/json_schema/module/biomaterial/death.json
+++ b/json_schema/module/biomaterial/death.json
@@ -15,7 +15,7 @@
         },
         "cause_of_death": {
             "description": "Cause of death from death report for human donor, from research lab for mouse.",
-            "$ref": "ontology.json"
+            "type": "string"
         }, 
         "cold_perfused": {
             "description": "Yes if perfused with cold fluid to help preserve tissues before heart stopped. No otherwise.",

--- a/json_schema/module/ontology/strain_ontology.json
+++ b/json_schema/module/ontology/strain_ontology.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id" : "http://schema.humancellatlas.org/module/ontology/4.0.0/strain_ontology.json",
+    "description": "A term that may be associated with a cell type-related ontology term",
+    "additionalProperties": false,
+        "required": [
+        "text"
+    ],
+    "title": "strain_ontology",
+    "properties": {
+        "$schema" : {
+            "pattern" : "http://schema.humancellatlas.org/module/ontology/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/strain_ontology.json",
+            "type": "string"
+        },
+        "text": {
+            "description": "The name of the strain to which the organism belongs (mouse-specific).",
+            "type": "string"
+        },
+        "ontology": {
+            "description": "An ontology term identifier in the form prefix:accession",
+            "type": "string",
+            "graph_restriction":  {
+                "ontologies" : ["obo:NCBITaxon", "obo:efo"],
+                "classes": ["NCBITaxon:131567", "EFO:0004472"],
+                "relations": ["rdfs:subClassOf"],
+                "direct": false,
+                "include_self": false
+            }
+        }
+    },
+    "type": "object"
+}

--- a/json_schema/type/biomaterial/organism.json
+++ b/json_schema/type/biomaterial/organism.json
@@ -17,7 +17,7 @@
                     "description": "The name of th mouse inbred strain. e.g. C57BL/6.",
                     "type": "array",
                     "items": {
-                        "$ref": "ontology.json"
+                        "$ref": "strain_ontology.json"
                     }
                 }
             }


### PR DESCRIPTION
… it from organism. Also removed ontology ref for CoD in death as there is currently no standardised representation of CoDs