### PR TITLE
Updated project_bundle schema. Updated automatic test.

### DIFF
--- a/json_schema/bundle/biomaterial_bundle.json
+++ b/json_schema/bundle/biomaterial_bundle.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle.json",
-    "description": "A schema for a biomaterial bundle",
+    "description": "A schema for a biomaterial bundle.",
     "additionalProperties": false,
     "required": [
         "$schema"
@@ -69,7 +69,9 @@
                 "analysis_bundle",
                 "biomaterial_bundle",
                 "process_bundle",
-                "project_bundle"
+                "project_bundle",
+                "ingest",
+                "submission"
             ]
         },
         "biomaterials": {

--- a/json_schema/bundle/ingest.json
+++ b/json_schema/bundle/ingest.json
@@ -4,6 +4,7 @@
     "description": "Information added or generated at time of ingest." ,
     "additionalProperties": false,
     "required": [
+        "$schema",
         "document_id",
         "submissionDate"
     ],
@@ -21,29 +22,46 @@
             "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
             "example": "4.6.1"
         },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle",
+                "ingest",
+                "submission"
+            ]
+        },
         "submissionDate": {
             "description": "When project was first submitted to database.", 
-            "format": "date-time", 
-            "type": "string"
-        }, 
+            "type": "string",
+            "format": "date-time"
+        },
         "submitter_id": {
             "description": "ID of contact who first submitted project", 
             "type": "string"
         },
         "updateDate": {
             "description": "When project was last updated", 
-            "format": "date-time",
-            "type": "string"
-        }, 
+            "type": "string",
+            "format": "date-time"
+        },
         "updater_id": {
             "description": "ID of contact who last updated project", 
             "type": "string"
         },
         "document_id": {
             "description": "Identifier for document.",
-            "comment": "This structure supports the current ingest API.  It may change in future.",
             "type": "string",
-            "pattern": ".{8}-.{4}-.{4}-.{4}-.{12}"
+            "pattern": ".{8}-.{4}-.{4}-.{4}-.{12}",
+            "comment": "This structure supports the current ingest API.  It may change in future."
         },
         "accession": {
             "description": "A unique accession for this entity, provided by the broker.",

--- a/json_schema/bundle/process_bundle.json
+++ b/json_schema/bundle/process_bundle.json
@@ -1,52 +1,79 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://schema.humancellatlas.org/bundle/5.0.0/process_bundle.json",
+    "description": "A schema for a process bundle.",
+    "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
+    "title": "process_bundle",
     "type": "object",
-    "description": "A schema for an process bundle",
-    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/process_bundle.json#/definitions/process_ingest",
     "definitions": {
         "process_ingest": {
             "required": [
                 "hca_ingest",
                 "content",
-                "core"
+                "has_input"
             ],
             "type": "object",
             "properties": {
-                "has_input": {
-                    "type": "string",
-                    "description": "The sample that this process was performed on."
-                },
                 "content": {
-                    "type": "object",
                     "description": "Process content",
+                    "type": "object",
                     "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/type/process/process.json"
                 },
+                "has_input": {
+                    "description": "The biomaterial or file that this process was performed on.",
+                    "type": "string"
+                },
                 "has_output": {
+                    "description": "The biomaterial or files that were generated from this process.",
+                    "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array",
-                    "description": "The files that were generated from this process."
-                },
-                "derivation_protocols": {
-                    "items": {
-                        "description": "An array of protocols used in derivation of this sample.",
-                        "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/protocol/protocol.json"
-                    },
-                    "type": "array"
+                    }
                 },
                 "hca_ingest": {
+                    "description": "Core fields added by HCA ingest service",
                     "type": "object",
-                    "description": "core fields added by HCA ingest service",
                     "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/ingest.json"
                 }
             }
         }
     },
-    "processes": {
-        "items": {
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/bundle/process_bundle.json#/definitions/process_ingest"
+    "properties": {
+        "$schema" : {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "http://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/biomaterial_bundle.json"
         },
-        "type": "array"
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle",
+                "ingest",
+                "submission"
+            ]
+        },
+        "processes": {
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/bundle/process_bundle.json#/definitions/process_ingest"
+            },
+            "type": "array"
+        }
     }
 }

--- a/json_schema/bundle/project_bundle.json
+++ b/json_schema/bundle/project_bundle.json
@@ -1,32 +1,52 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://schema.humancellatlas.org/bundle/5.0.0/project_bundle.json",
+    "description": "A schema for a project bundle.",
+    "additionalProperties": false,
+    "required": [
+        "$schema",
+        "hca_ingest",
+        "content"
+    ],
+    "title": "project_bundle",
     "type": "object",
-    "description": "A schema for a project bundle",
-    "id": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/project_bundle.json#/definitions/project_ingest",
-    "definitions": {
-        "project_ingest": {
-            "required": [
-                "hca_ingest",
-                "content",
-                "core"
-            ],
+    "properties": {
+        "$schema": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern": "http://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/biomaterial_bundle.json"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle",
+                "ingest",
+                "submission"
+            ]
+        },
+        "content": {
+            "description": "Content for a project type entity.",
             "type": "object",
-            "properties": {
-                "content": {
-                    "type": "object",
-                    "description": "Project content",
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/project.json"
-                },
-                "core": {
-                    "description": "Type and schema for this object.",
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/core.json"
-                },
-                "hca_ingest": {
-                    "type": "object",
-                    "description": "core fields added by HCA ingest service",
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/ingest.json"
-                }
-            }
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/project/project.json"
+        },
+        "hca_ingest": {
+            "description": "Core fields added by HCA ingest service",
+            "type": "object",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/ingest.json"
         }
     }
 }

--- a/json_schema/bundle/submission.json
+++ b/json_schema/bundle/submission.json
@@ -4,6 +4,7 @@
     "description": "Information added to a submission at ingest." ,
     "additionalProperties": false,
 	"required": [
+		"$schema",
     	"transfer_service_version",
 		"submitted_files"
     ],
@@ -87,13 +88,36 @@
 			"type": "string",
       	  	"pattern": "http://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/submission.json"
     	},
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle",
+                "ingest",
+                "submission"
+            ]
+        },
     	"transfer_service_version" : {
 			"description": "",
-			"$ref": "submission.json#/definitions/transfer_service_version"
+			"$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/submission.json#/definitions/transfer_service_version"
 		},
 		"submitted_files" : {
 			"description": "",
-			"$ref": "submission.json#/definitions/submitted_files"
+			"$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/submission.json#/definitions/submitted_files"
 		}
     }
 }

--- a/schema_test_files/project/test_pass_project_bundle.json
+++ b/schema_test_files/project/test_pass_project_bundle.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle.json",
+  "schema_version": "5.0.0",
+  "schema_type": "project_bundle",
+  "content": {
+    "$schema": "http://schema.humancellatlas.org/type/project/5.0.0/project.json",
+    "schema_version" : "5.0.0",
+    "schema_type": "project",
+    "project_core": {
+      "$schema": "http://schema.humancellatlas.org/core/project/5.0.0/project_core.json",
+      "project_id": "p1",
+      "project_title": "project 1",
+      "project_description": "This is a project."
+    },
+    "related_projects": [
+      "project 2"
+    ],
+    "contributors": [
+      {
+        "$schema": "http://schema.humancellatlas.org/module/project/5.0.0/contact.json",
+        "contact_name": "Q3_DEMO-MintTeam",
+        "email": "dummy@email.com"
+      }
+    ]
+  },
+  "hca_ingest": {
+    "accession": "HCAP-001",
+    "submissionDate": "2017-12-16T01:43:43.381Z",
+    "updateDate": "2017-12-16T01:44:25.613Z",
+    "document_id": "19d3e86b-9af2-44c2-b9bd-50c159b044f1"
+  }
+}

--- a/schema_test_files/project/test_pass_project_bundle.json
+++ b/schema_test_files/project/test_pass_project_bundle.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle.json",
+  "$schema": "http://schema.humancellatlas.org/bundle/5.0.0/project_bundle.json",
   "schema_version": "5.0.0",
   "schema_type": "project_bundle",
   "content": {
@@ -13,7 +13,7 @@
       "project_description": "This is a project."
     },
     "related_projects": [
-      "project 2"
+      "HCAP-002"
     ],
     "contributors": [
       {

--- a/src/json_examples_validate_against_schema.py
+++ b/src/json_examples_validate_against_schema.py
@@ -32,7 +32,7 @@ if not validate(sv, p1):
 # It is missing required project_id field
 print('\nValidating type/project/project.json schema')
 sv = get_validator('type/project/project.json', base_uri)
-print('Validating project/test_fail_project_0.json JSON against schema\n(This should fail)')
+print('Validating project/test_fail_project_0.json JSON against schema\n(This should fail, missing project_id)')
 p1 = get_json_from_file('../schema_test_files/project/test_fail_project_0.json')
 if validate(sv, p1):
     status_flag = False
@@ -57,7 +57,7 @@ if not validate(sv, s1):
 # It is missing required ncbi_taxon_id field
 print('\nValidating type/biomaterial/specimen_from_organism.json schema')
 sv = get_validator('type/biomaterial/specimen_from_organism.json', base_uri)
-print('Validating biomaterial/test_fail_specimen_0.json JSON against schema\n(This should fail)')
+print('Validating biomaterial/test_fail_specimen_0.json JSON against schema\n(This should fail, missing ncbi_taxon_id)')
 s2 = get_json_from_file('../schema_test_files/biomaterial/test_fail_specimen_0.json')
 if validate(sv, s2):
     status_flag = False
@@ -76,9 +76,17 @@ if not validate(sv, b1):
 # Bundle is missing hca_ingest property in one of the biomaterials
 print('\nValidating bundle/biomaterial_bundle.json schema')
 sv = get_validator('bundle/biomaterial_bundle.json', base_uri)
-print('Validating biomaterial/test_fail_biomaterial_bundle.json JSON against schema\n(This should fail)')
+print('Validating biomaterial/test_fail_biomaterial_bundle.json JSON against schema\n(This should fail, missing hca_ingest)')
 b2 = get_json_from_file('../schema_test_files/biomaterial/test_fail_biomaterial_bundle.json')
 if validate(sv, b2):
+    status_flag = False
+
+# Testing valid project bundle example
+print('\nValidating bundle/project_bundle.json schema')
+sv = get_validator('bundle/project_bundle.json', base_uri)
+print('Validating project/test_pass_project_bundle.json JSON against schema')
+b1 = get_json_from_file('../schema_test_files/project/test_pass_project_bundle.json')
+if not validate(sv, b1):
     status_flag = False
 
 # If any of the validate() calls fail, set exit status to 1.


### PR DESCRIPTION
General updates to bundle/ingest/submission JSONs:
- Updated bundle descriptions
- Reordered bundle schema attributes to be consistent
- Added "ingest" and "submission" to the enum of `schema_types`
- Added `$schema` to list of required properties where missing
- Added `schema_type` property, `additionalProperties:false`, and `required` where missing
- Changed `$ref` to `id` in `process_bundle.json`
- Removed reference to `core` since we don't use `core.json` anymore
- Updated $refs for subschemas so that they point to the correct subschema

Structural changes specifically to `process_bundle.json`:
- Made the `has_input` property required because we are not allowing submission of a process without supplying which biomaterial/file the process was applied to. Protocols CAN be submitted without these entities, though.
- Removed `derivation_protocols` property. This field was inappropriately copied from biomaterial_bundle.json. 
- Added structure to the bundle to match that of the `biomaterial_bundle.json` schema so that the process bundle is an array of entities pointing to the `process_ingest` definition.

Structural changes specifically to `project_bundle.json`:
- Removed the `definition` structure and converted strictly to properties. We are not expecting arrays of project entities in a bundle - unlike what we expect for biomaterials and processes - so the definition structure is unnecessary

Updates to automated test to Travis CI:
- Added a passing example project bundle
- Updated automatic testing script to include testing the passing project bundles against the project_bundle.json schema