### PR TITLE
Added purchased_reagents module and linked to process types.

### DIFF
--- a/json_schema/core/protocol/protocol_core.json
+++ b/json_schema/core/protocol/protocol_core.json
@@ -51,28 +51,23 @@
             "type": "string",
             "user_friendly": "Protocol description"
         },
-        "doi": {
+        "publication_doi": {
             "description": "The publication digital object identifier (doi) associated with the protocol.",
             "type": "string",
-            "example": "10.1016/j.cell.2016.07.054",
-            "user_friendly": "DOI"
+            "example": "10.1101/193219",
+            "user_friendly": "Publication DOI"
+        },
+        "protocols_io_doi": {
+            "description": "The protocols.io digital object identifier (doi) associated with the protocol.",
+            "type": "string",
+            "example": "10.17504/protocols.io.mgjc3un",
+            "user_friendly": "protocols.io DOI"
         },
         "pdf": {
             "description": "A filename of a PDF containing the details of the protocol.",
             "type": "string",
             "pattern": "^.*.pdf$",
-            "user_friendly": "PDF"
-        },
-        "retail_name": {
-            "description": "The retail name of the protocol kit used.",
-            "type": "string",
-            "example": "SureCell WTA 3' Library Prep Kit",
-            "user_friendly": "Retail name"
-        },
-         "batch_number": {
-            "description": "The batch of protocol kit used.",
-            "type": "string",
-            "user_friendly": "Batch number"
+            "user_friendly": "PDF filename"
         }
     }
 }

--- a/json_schema/module/process/purchased_reagents.json
+++ b/json_schema/module/process/purchased_reagents.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://schema.humancellatlas.org/module/process/5.0.0/purchased_reagents.json",
+    "description": "This module describes purchased kits or reagents used in any process.",
+    "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
+    "title": "purchased_reagents",
+    "type": "object",
+    "properties": {
+        "$schema" : {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "http://schema.humancellatlas.org/module/process/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/purchased_reagents.json"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle"
+            ]
+        },
+        "retail_name": {
+          "description": "The retail name of the kit/reagent.",
+          "type": "string",
+          "example": "SureCell WTA 3' Library Prep Kit",
+          "user_friendly": "Retail name"
+        },
+        "catalog_number": {
+          "description": "The catalog number of the kit/reagent.",
+          "type": "string",
+          "example": "20014279",
+          "user_friendly": "Catalog number"
+        },
+        "manufacturer": {
+           "description": "The manufacturer of the kit/reagent.",
+           "type": "string",
+           "example": "Illumina",
+           "user_friendly": "Manufacturer"
+        },
+        "batch_number": {
+           "description": "The batch or lot number of the kit/reagent.",
+           "type": "string",
+           "example": "10001A",
+           "user_friendly": "Batch/lot number"
+        },
+        "expiry_date": {
+           "description": "The date of expiration for the kit/reagent.",
+            "type": "string",
+            "format": "date",
+            "example": "2018-01-31",
+            "user_friendly": "Expiry date"
+        }
+	}
+}

--- a/json_schema/type/process/biomaterial_collection/collection_process.json
+++ b/json_schema/type/process/biomaterial_collection/collection_process.json
@@ -40,6 +40,11 @@
 	        "description": "Core process-level information.",
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/core/process/process_core.json"
         },
+        "process_type": {
+            "description": "The type of process. Ideally an EFO term.",
+            "$ref": "module/ontology/process_type_ontology.json",
+            "user_friendly": "Process type"
+        },
         "collection_method": {
             "description": "How the biomaterial was collected.",
             "type": "string",
@@ -52,10 +57,12 @@
             ],
             "user_friendly": "Collection method"
         },
-        "process_type": {
-            "description": "The type of process. Ideally an EFO term.",
-            "$ref": "module/ontology/process_type_ontology.json",
-            "user_friendly": "Process type"
+        "process_reagents": {
+            "description": "A list of purchased reagents used in this process.",
+            "type": "array",
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/process/purchased_reagents.json"
+            }
         }
     }
 }

--- a/json_schema/type/process/biomaterial_collection/dissociation_process.json
+++ b/json_schema/type/process/biomaterial_collection/dissociation_process.json
@@ -73,6 +73,13 @@
             "description": "The type of process. Ideally an EFO term.",
             "$ref": "module/ontology/process_type_ontology.json",
             "user_friendly": "Process type"
+        },
+        "process_reagents": {
+            "description": "A list of purchased reagents used in this process.",
+            "type": "array",
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/process/purchased_reagents.json"
+            }
         }
     }
 }

--- a/json_schema/type/protocol/protocol.json
+++ b/json_schema/type/protocol/protocol.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://schema.humancellatlas.org/type/protocol/4.0.0/protocol.json",
+    "id": "http://schema.humancellatlas.org/type/protocol/5.0.0/protocol.json",
     "description": "Information about the protocol",
     "additionalProperties": false,
     "required": [


### PR DESCRIPTION
- Added new module `purchased_reagents` as a process module
- Moved `retail_name` and `batch_number` from `protocol_core.json` to a new process module `purchased_reagents.json`
- Added fields to `puchased_reagents.json` module: `catalog_number`, `manufacturer`, `expiry_date`-
- Added a `protocols_io_doi` field to `protocol_core.json`
- Renamed `doi` field to `publication_doi` to differentiate from a protocols.io DOI (in case users have both to give)
- Updated example, user_friendly, and description attributes for fields in `protocol_core.json`
- Added reference to `purchased_reagents` module in `collection_process.json` and `dissociated_process.json` entities