### PR TITLE
Handles a purchased_reagents module.

### DIFF
--- a/src/json_to_spreadsheet_template.py
+++ b/src/json_to_spreadsheet_template.py
@@ -9,7 +9,7 @@ from openpyxl.styles import Font
 # hard coded tab ordering
 tab_ordering = ["project", "project.publications", "contact", "organism", "familial_relationship", "specimen_from_organism", "cell_suspension",
                 "cell_line", "cell_line.publications", "organoid", "collection_process", "dissociation_process", "enrichment_process", "library_preparation_process",
-                "sequencing_process", "sequence_file", "protocol"]
+                "sequencing_process", "purchased_reagents", "protocol", "sequence_file"]
 
 class SpreadsheetCreator:
 
@@ -102,6 +102,10 @@ class SpreadsheetCreator:
             if "type/process" in schema:
                 values.append(
                     {"header": "Protocol IDs", "description": "IDs of protocols which this process implements",
+                     "example": None})
+            if "module/process/purchased_reagents" in schema:
+                values.append(
+                    {"header": "Process ID", "description": "ID of the process in which this reagent was used",
                      "example": None})
             if "type/file" in schema:
                 values.append(


### PR DESCRIPTION
- Including a "purchased_reagents" tab for users to list info about any reagents/kits used in any process. The tab is listed after all process tabs, before the protocol tab. 
- The sequence_file tab was moved to the end.
- Handling of a Process ID header in the purchased_reagents tab for users to link which process used that reagent/kit