### PR TITLE
Added a growth_conditions biomaterial module.

### DIFF
--- a/json_schema/module/biomaterial/growth_conditions.json
+++ b/json_schema/module/biomaterial/growth_conditions.json
@@ -59,6 +59,12 @@
             "type": "string",
             "example": "No spots of bright blue stain observed at high magnification",
             "user_friendly": "Mycoplasma testing results"
+        },
+        "drug_treatment": {
+            "description": "Description of drugs added to the growth medium for this biomaterial.",
+            "type": "string",
+            "example": "100 ug/mL ampicillin",
+            "user_friendly": "Drug treatment"
         }
     }
 }

--- a/json_schema/module/biomaterial/growth_conditions.json
+++ b/json_schema/module/biomaterial/growth_conditions.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://schema.humancellatlas.org/module/biomaterial/5.0.0/growth_conditions.json",
+    "description": "Information relating to how a biomaterial was grown and/or maintained in a laboratory setting.",
+    "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
+    "title": "growth_conditions",
+    "type": "object",
+    "properties": {
+        "$schema" : {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "http://schema.humancellatlas.org/module/biomaterial/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/growth_conditions.json"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle"
+            ]
+        },
+        "passage_number": {
+            "description": "The number of passages the cell line has been through.",
+            "maximum": 1000,
+            "minimum": 0,
+            "type": "integer",
+            "user_friendly": "Passage number"
+        },
+        "growth_medium": {
+            "description": "The solid, liquid, or semi-solid medium used to support the growth of the biomaterial.",
+            "type": "string",
+            "example": "lysogeny broth (LB) medium",
+            "user_friendly": "Growth medium"
+        },
+        "mycoplasma_testing_method": {
+            "description": "The method used for detecting mycoplasma contamination of a biomaterial culture.",
+            "type": "string",
+            "example": "Indirect DNA stain using Hoechst 33258 with 3T3 indicator cells",
+            "user_friendly": "Mycoplasma testing method"
+        },
+        "mycoplasma_testing_results": {
+            "description": "Results of mycoplasma testing of a biomaterial culture.",
+            "type": "string",
+            "example": "No spots of bright blue stain observed at high magnification",
+            "user_friendly": "Mycoplasma testing results"
+        }
+    }
+}

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -72,6 +72,11 @@
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
             "user_friendly": "Cell morphology"
         },
+        "growth_conditions": {
+            "description": "Features relating to the growth and/or maintenance of a biomaterial.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
+            "user_friendly": "Growth conditions"
+        },
         "cell_type": {
 	        "description": "The cell type that the cell line was derived from. Should be a CLO ontology.",
             "$ref": "module/ontology/cell_type_ontology.json",
@@ -96,13 +101,6 @@
                 "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/species_ontology.json"
             },
             "user_friendly": "Genus species"
-        },
-        "passage_number": {
-            "description": "The number of passages the cell line has been through.",
-            "maximum": 1000,
-            "minimum": 0,
-            "type": "integer",
-            "user_friendly": "Passage number"
         },
         "publications": {
             "description": "One or more publications in which the cell line creation was cited.",

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -45,6 +45,11 @@
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
             "user_friendly": "Cell morphology"
         },
+        "growth_conditions": {
+            "description": "Features relating to the growth and/or maintenance of a biomaterial.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
+            "user_friendly": "Growth conditions"
+        },
         "genus_species": {
             "description": "The scientific binomial name for the species of the biomaterial.",
             "type" : "array",

--- a/json_schema/type/biomaterial/organoid.json
+++ b/json_schema/type/biomaterial/organoid.json
@@ -42,8 +42,14 @@
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/core/biomaterial/biomaterial_core.json"
         },
         "cell_morphology": {
-	        "description": "Features relating to the morphology of cells in a biomaterial.",
-            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json"
+            "description": "Features relating to the morphology of cells in a biomaterial.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
+            "user_friendly": "Cell morphology"
+        },
+        "growth_conditions": {
+            "description": "Features relating to the growth and/or maintenance of a biomaterial.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/cell_morphology.json",
+            "user_friendly": "Growth conditions"
         },
         "genus_species": {
             "description": "The scientific binomial name for the species of the biomaterial.",


### PR DESCRIPTION
This PR is to add a new module - growth_conditions - to the set of biomaterial modules. This module contains fields relating to the growth or maintenance of a biomaterial in culture. This module has been added to the schemas for cell line, organoid, and cell suspension. The changes include:
- Addition of the module - `growth_conditions.json` - to `json_schema/module/biomaterials/`
- Addition of `growth_conditions` field to `cell_line.json`, `cell_suspension.json`, and `organoid.json`
- Removal of `passage_number` field from `cell_line.json` because it is now in the module
- Added missing `user_friendly` attribute to `cell_morphology` field in `organoid.json`