### PR TITLE
V5 prototype schema reviews

### DIFF
--- a/json_schema/core/process/process_core.json
+++ b/json_schema/core/process/process_core.json
@@ -65,7 +65,7 @@
             "user_friendly": "Location"
          },
          "operator_identity": {
-           "description": "Identity of individual(s) who executed this process.",
+           "description": "Identifier for individual(s) who executed this process.",
            "type": "array",
            "example": "Technician 1",
            "items":{

--- a/json_schema/core/process/process_core.json
+++ b/json_schema/core/process/process_core.json
@@ -64,14 +64,14 @@
             "example": "Wellcome Sanger Institute, Teichman Lab.",
             "user_friendly": "Location"
          },
-         "researcher": {
-           "description": "Name of the individual(s) who executed this process.",
+         "operator_identity": {
+           "description": "Identity of individual(s) who executed this process.",
            "type": "array",
-           "example": "John Smith||Jane Doe",
+           "example": "Technician 1",
            "items":{
                 "type": "string"
            },
-           "user_friendly": "Researcher"
+           "user_friendly": "Operator identity"
          }
     }
 }

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -64,9 +64,9 @@
        },
         "total_estimated_cells": {
             "description": "Total estimated number of cells in biomaterial. May be 1 for well-based assays.",
-            "type": "number",
-            "maximum": 1000000000.0,
-            "minimum": 0.1,
+            "type": "integer",
+            "maximum": 1000000000,
+            "minimum": 0,
             "user_friendly": "Total estimated cell count"
         }
      }

--- a/json_schema/type/biomaterial/organism.json
+++ b/json_schema/type/biomaterial/organism.json
@@ -122,8 +122,8 @@
             "type": "boolean",
             "user_friendly": "Is living?"
         }, 
-        "sex": {
-            "description": "Sex of organism. Should be one of male, female, mixed, or unknown.",
+        "biological_sex": {
+            "description": "The biological sex of the organism. Should be one of male, female, mixed, or unknown.",
             "type": "string",
             "enum": [
                 "female", 

--- a/json_schema/type/biomaterial/organism.json
+++ b/json_schema/type/biomaterial/organism.json
@@ -107,11 +107,15 @@
             "user_friendly": "Gestational age unit"
         },
         "height": {
-            "description": "Height of organism in meters.",
+            "description": "Height of organism in height units.",
             "type": "number",
-            "maximum": 10, 
-            "minimum": 0,
+            "minimum": 0.0,
             "user_friendly": "Height"
+        },
+        "height_unit": {
+            "description": "The unit in which height is expressed. Must be one of centimeters, meters, or inches.",
+            "type": "string",
+            "user_friendly": "Height unit"
         },
         "is_living": {
             "description": "Yes if organism is living at time of biomaterial collection. No otherwise.",
@@ -132,9 +136,13 @@
         "weight": {
             "description": "Weight of organism in kilograms.",
             "type": "number",
-            "maximum": 1000, 
-            "minimum": 0,
+            "minimum": 0.0,
             "user_friendly": "Weight"
+        },
+        "weight_unit": {
+            "description": "The unit in which weight is expressed. Must be one of gram, kilogram, pound.",
+            "type": "string",
+            "user_friendly": "Weight unit"
         }
     }
 }

--- a/json_schema/type/biomaterial/organism.json
+++ b/json_schema/type/biomaterial/organism.json
@@ -50,8 +50,12 @@
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/non_homo_sapiens_specific.json"
         },
         "death": {
-            "description": "Information about conditions of death (or info that organism was living at time of collection).",
+            "description": "Information about conditions of death of an organism.",
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/death.json"
+        },
+        "medical_history": {
+            "description": "Information about the medical history of an organism.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/medical_history.json"
         },
         "genus_species": {
             "description": "The scientific binomial name for the species of the biomaterial.",

--- a/json_schema/type/process/sequencing/library_preparation_process.json
+++ b/json_schema/type/process/sequencing/library_preparation_process.json
@@ -76,6 +76,7 @@
                 "TruSeq",
                 "unknown"
             ],
+            "comment": "This will become an ontology.",
             "user_friendly": "Library construction approach"
         },
         "end_bias": {


### PR DESCRIPTION
Minor revisions made based on a global review of all core and type fields in all schemata. Revisions include:
- Changed `name` to `operator_identity` to describe person who did a process. Fixes #123. 
- Changed `sex` to `biological_sex`. Fixes #125.
- Added unit fields for height and weight in `organism.json`. Fixes #126. Fixes #81.
- Changed `total_estimated_cells` from number to integer. Fixes #127.
- Added comment that `library_construction` will become an ontology. Fixes #128. Also referenced in #92.
- Added `medical_history` field to reference module in `organism.json`. Fixes #129.