### PR TITLE
V5 prototype new preservation/storage module

### DIFF
--- a/json_schema/module/biomaterial/preservation_storage.json
+++ b/json_schema/module/biomaterial/preservation_storage.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://schema.humancellatlas.org/module/biomaterial/5.0.0/preservation_storage.json",
+    "description": "Information relating to how a biomaterial was preserved and/or stored over a period of time.",
+    "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
+    "title": "preservation_storage",
+    "type": "object",
+    "properties": {
+        "$schema" : {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "http://schema.humancellatlas.org/module/biomaterial/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/preservation_storage.json"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial",
+                "file",
+                "process",
+                "project",
+                "protocol",
+                "analysis_bundle",
+                "biomaterial_bundle",
+                "process_bundle",
+                "project_bundle"
+            ]
+        },
+        "storage_method": {
+            "description": "The method by which a biomaterial was stored.",
+            "type": "string",
+            "enum": [
+                "ambient temperature",
+                "cut slide",
+                "fresh",
+                "frozen, -70C freezer",
+                "frozen, -150C freezer",
+                "frozen, liquid nitrogen",
+                "frozen, vapor phase",
+                "paraffin block",
+                "RNAlater, frozen",
+                "TRIzol, frozen"
+            ],
+            "comment": "Refers to how a biomaterial was stored after preservation or before another protocol was used.",
+            "user_friendly": "Storage method"
+        },
+        "storage_time": {
+            "description": "Length of time the biomaterial was stored for in Storage time units.",
+            "type": "number",
+            "example": 5,
+            "user_friendly": "Storage time"
+        },
+        "storage_time_unit": {
+            "description": "The unit in which Storage time is expressed.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/time_unit_ontology.json",
+            "example": "days",
+            "user_friendly": "Storage time unit"
+        },
+        "preservation_method": {
+            "description": "The method by which a biomaterial was preserved or not.",
+            "type": "string",
+            "enum": [
+                "cryopreservation in liquid nitrogen (dead tissue)",
+                "cryopreservation in dry ice (dead tissue)",
+                "cryopreservation of live cells in liquid nitrogen",
+                "cryopreservation, other",
+                "formalin fixed, unbuffered",
+                "formalin fixed, buffered",
+                "formalin fixed and paraffin embedded",
+                "Fresh"
+            ],
+            "comment": "Refers to the use of chemicals, cold, or other means to prevent or retard biological or physical deterioration of a biomaterial.",
+            "user_friendly": "Storage method"
+        }
+    }
+}

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -66,11 +66,15 @@
             "user_friendly": "Organ part"
         },
         "state_of_specimen": {
-            "description": "State of the specimen at the time of collection and how it was preserved after removal.",
+            "description": "State of the specimen at the time of collection/removal.",
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/state_of_specimen.json"
         },
+        "preservation_storage": {
+            "description": "Information relating to how a biomaterial was preserved and/or stored over a period of time.",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/preservation_storage.json"
+        },
         "collection_time": {
-            "description": "When the biomaterial was collection, in date-time format, yyyy-mm-ddThh:mm:ssZ.",
+            "description": "When the biomaterial was collected, in date-time format, yyyy-mm-ddThh:mm:ssZ.",
             "type": "string",
             "format": "date-time",
             "user_friendly": "Time of collection"

--- a/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
@@ -17,6 +17,7 @@
           ]
         },
         "is_living": true,
+        "biological_sex": "male",
         "development_stage": {
           "$schema": "http://schema.humancellatlas.org/module/ontology/5.0.0/development_stage_ontology.json",
           "text": "adult",

--- a/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
@@ -24,6 +24,7 @@
           ]
         },
         "is_living": true,
+        "biological_sex": "male",
         "development_stage": {
           "$schema": "http://schema.humancellatlas.org/module/ontology/5.0.0/development_stage_ontology.json",
           "text": "adult",


### PR DESCRIPTION
This new module contains information that was actually lost from v3, information about how a specimen was preserved and/or stored. Preservation specifically refers to the use of chemicals, cold, or other means to prevent or retard biological or physical deterioration of a biomaterial. Storage specifically refers to how a biomaterial was stored after preservation or before another protocol was used. This module currently is associated with the specimen_from_organism entity, but it is generic enough that we might consider allowing it to be submitted with cell_suspension, cell_line, and organoid. It is probably not relevant for organism.