### PR TITLE
Added oneOf link to process type refs.

### DIFF
--- a/json_schema/bundle/process_bundle.json
+++ b/json_schema/bundle/process_bundle.json
@@ -18,9 +18,17 @@
             "type": "object",
             "properties": {
                 "content": {
-                    "description": "Process content",
+                    "description": "Content for any process type entity.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/type/process/process.json"
+                    "oneOf": [
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/analysis/analysis.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/biomaterial_collection/collection_process.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/biomaterial_collection/dissociation_process.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/biomaterial_collection/enrichment_process.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/imaging/imaging_process.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/sequencing/library_preparation_process.json" },
+                        { "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/type/process/sequencing/sequencing_process.json" }
+                    ]
                 },
                 "has_input": {
                     "description": "The biomaterial or file that this process was performed on.",


### PR DESCRIPTION
In copying process_bundle schema from assay bundle schema in v4.6.1, the content of the bundle was pointing to a single process stub schema. In v5, the content block needs to be one of the process type entities.

Changes pass Travis CI tests.

Please delete this branch after merging.