### PR TITLE
Minor fix to integration of modules as separate tabs

### DIFF
--- a/src/json_to_spreadsheet_template.py
+++ b/src/json_to_spreadsheet_template.py
@@ -58,7 +58,7 @@ class SpreadsheetCreator:
                                     t = primary["header"]
                                     t = t.replace(" ID", "").lower()
                                     d = "ID for " + t + " this " + key + " relates to"
-                                    module_values[key].append({"header": t,
+                                    module_values[key].append({"header": primary["header"],
                                                                "description": d,
                                                                "example": None})
                                 break


### PR DESCRIPTION
Very minor code change in the json schema to template code to fix cross-ref header in dependent tabs (eg biomaterial ID in familial relationship tab etc).