### PR TITLE
Add example to organoid_age in organoid.json

### DIFF
--- a/json_schema/type/biomaterial/organoid.json
+++ b/json_schema/type/biomaterial/organoid.json
@@ -68,6 +68,7 @@
         "organoid_age": {
             "description": "Age of the organoid.",
             "type": "number",
+            "example": 55,
             "user_friendly": "Organoid age"
         },
         "organoid_age_unit": {


### PR DESCRIPTION
I added an example attribute to the organoid_age field in the organoid.json file. 