### PR TITLE
V5 prototype bundle fixes

### DIFF
--- a/json_schema/bundle/process_bundle.json
+++ b/json_schema/bundle/process_bundle.json
@@ -71,10 +71,10 @@
             ]
         },
         "processes": {
+            "type": "array",
             "items": {
                 "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/bundle/process_bundle.json#/definitions/process_ingest"
-            },
-            "type": "array"
+            }
         }
     }
 }

--- a/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
@@ -63,7 +63,7 @@
           "text": "peripheral blood mononuclear cells (PBMCs)"
         }
       },
-      "derived_from": "a37dbd93-b93a-4838-a7bb-cd0796b3d9d1",
+      "derived_from": ["a37dbd93-b93a-4838-a7bb-cd0796b3d9d1"],
       "derivation_protocols": []
     }
   ]

--- a/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
@@ -71,7 +71,7 @@
           "text": "peripheral blood mononuclear cells (PBMCs)"
         }
       },
-      "derived_from": "a37dbd93-b93a-4838-a7bb-cd0796b3d9d1",
+      "derived_from": ["a37dbd93-b93a-4838-a7bb-cd0796b3d9d1"],
       "derivation_protocols": []
     }
   ]

--- a/schema_test_files/process/test_pass_process_bundle.json
+++ b/schema_test_files/process/test_pass_process_bundle.json
@@ -51,6 +51,33 @@
         "strand": "first",
         "library_construction": "smart-seq2"
       }
+    },
+    {
+      "hca_ingest": {
+        "$schema": "http://schema.humancellatlas.org/bundle/5.0.0/ingest.json",
+        "accession": "",
+        "submissionDate": "2017-12-16T01:43:43.467Z",
+        "updateDate": "2017-12-16T01:44:24.837Z",
+        "document_id": "63688c4a-1280-4eb7-a431-2456f89c3cdf"
+      },
+      "has_input": [
+        "2896fd1c-e99b-4763-9988-f6093d749240"
+      ],
+      "has_output": [
+        "fc60c1cf-ffd1-4bdb-b06c-b31896efcd46"
+      ],
+      "content": {
+        "$schema": "http://schema.humancellatlas.org/type/process/sequencing/5.0.0/sequencing_process.json",
+        "process_core": {
+          "$schema": "http://schema.humancellatlas.org/core/process/5.0.0/process_core.json",
+          "process_id": "seq_protocol_1"
+        },
+        "paired_ends": true,
+        "instrument_manufacturer_model": {
+          "$schema": "http://schema.humancellatlas.org/module/ontology/5.0.0/instrument_ontology.json",
+          "text": "Illumina HiSeq 4000"
+        }
+      }
     }
     ]
 }

--- a/schema_test_files/process/test_pass_process_bundle.json
+++ b/schema_test_files/process/test_pass_process_bundle.json
@@ -51,30 +51,6 @@
         "strand": "first",
         "library_construction": "smart-seq2"
       }
-    },
-    {
-      "hca_ingest": {
-        "$schema": "http://schema.humancellatlas.org/bundle/5.0.0/ingest.json",
-        "accession": "",
-        "submissionDate": "2017-12-16T01:43:43.467Z",
-        "updateDate": "2017-12-16T01:44:24.837Z",
-        "document_id": "63688c4a-1280-4eb7-a431-2456f89c3cdf"
-      },
-      "has_input": [
-        "2896fd1c-e99b-4763-9988-f6093d749240"
-      ],
-      "has_output": [
-        "fc60c1cf-ffd1-4bdb-b06c-b31896efcd46"
-      ],
-      "content": {
-        "$schema": "http://schema.humancellatlas.org/type/process/sequencing/5.0.0/sequencing_process.json",
-        "process_core": {
-          "$schema": "http://schema.humancellatlas.org/core/process/5.0.0/process_core.json",
-          "process_id": "seq_protocol_1"
-        },
-        "paired_ends": true,
-        "instrument_manufacturer_model": "Illumina HiSeq 4000"
-      }
     }
     ]
 }

--- a/schema_test_files/process/test_pass_sequencing_process.json
+++ b/schema_test_files/process/test_pass_sequencing_process.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://schema.humancellatlas.org/type/process/sequencing/5.0.0/sequencing_process.json",
+  "process_core": {
+    "$schema": "http://schema.humancellatlas.org/core/process/5.0.0/process_core.json",
+    "process_id": "seq_protocol_1"
+  },
+  "paired_ends": true,
+  "instrument_manufacturer_model": {
+    "$schema": "http://schema.humancellatlas.org/module/ontology/5.0.0/instrument_ontology.json",
+    "text": "Illumina HiSeq 4000"
+  }
+}

--- a/src/json_examples_validate_against_schema.py
+++ b/src/json_examples_validate_against_schema.py
@@ -89,6 +89,14 @@ b1 = get_json_from_file('../schema_test_files/project/test_pass_project_bundle.j
 if not validate(sv, b1):
     status_flag = False
 
+# Testing valid process example
+print('\nValidating type/process/sequencing/sequencing_process.json schema')
+sv = get_validator('type/process/sequencing/sequencing_process.json', base_uri)
+print('Validating process/test_pass_sequencing_process.json JSON against schema')
+b1 = get_json_from_file('../schema_test_files/process/test_pass_sequencing_process.json')
+if not validate(sv, b1):
+    status_flag = False
+
 # Testing valid process bundle example
 print('\nValidating bundle/process_bundle.json schema')
 sv = get_validator('bundle/process_bundle.json', base_uri)


### PR DESCRIPTION
This PR fixed bundle validation errors. The value for `instrument_manufacturer_model` in the test example process bundle was given as a string, when it actually needs to be an object as this is an ontology field and thus needs to be passed the ontology module.
Also in this PR:
- a single process JSON test example fie (`test_pass_sequencing_process.json`) was added
- a test to validate new process test JSON was added to validation script
- `derived_from` fields in biomaterial bundles were changes to arrays as per the new bundle schema 