### PR TITLE
Made dissociation_method required to reflect same requirement in v4.

### DIFF
--- a/json_schema/type/process/biomaterial_collection/dissociation_process.json
+++ b/json_schema/type/process/biomaterial_collection/dissociation_process.json
@@ -6,7 +6,8 @@
     "required": [
         "$schema",
         "schema_type",
-        "process_core"
+        "process_core",
+        "dissociation_method"
     ],
     "title": "dissociation_process",
     "type": "object",
@@ -30,7 +31,7 @@
             ]
         },
         "process_core" : {
-	        "description": "Core process-level information.",
+            "description": "Core process-level information.",
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/core/process/process_core.json"
         },
         "dissociation_method": {


### PR DESCRIPTION
In v4.6.1, the field was called `cell_handling` in `single_cell.json` and was required. We should maintain this requirement.