### PR TITLE
Made input_molecule required as it is in v4.

### DIFF
--- a/json_schema/type/process/sequencing/library_preparation_process.json
+++ b/json_schema/type/process/sequencing/library_preparation_process.json
@@ -9,7 +9,8 @@
         "process_core",
         "end_bias",
         "library_construction",
-        "strand"
+        "strand",
+        "input_molecule"
     ],
     "title": "library_preparation_process",
     "type": "object",


### PR DESCRIPTION
The corresponding `molecule` field in v4's `seq.json` schema is required, so the newly named `input_molecule` field should be required, too. It is a necessary field for workflows.