### PR TITLE
Added new required input_molecule field to test process_bundle.

### DIFF
--- a/json_schema/type/process/sequencing/library_preparation_process.json
+++ b/json_schema/type/process/sequencing/library_preparation_process.json
@@ -46,7 +46,7 @@
         "input_molecule": {
             "description": "Specific type of nucleic acid molecule from which a sequencing library was prepared.",
             "type": "string",
-            "$ref": "module/ontology/biological_macromolecule_ontology.json",
+            "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/biological_macromolecule_ontology.json",
             "user_friendly": "Input molecule"
         },
         "library_construction": {

--- a/schema_test_files/process/test_pass_process_bundle.json
+++ b/schema_test_files/process/test_pass_process_bundle.json
@@ -51,6 +51,10 @@
         },
         "end_bias": "five_prime_end",
         "strand": "first",
+        "input_molecule": {
+          "$schema": "http://schema.humancellatlas.org/module/ontology/5.0.0/biological_macromolecule_ontology.json",
+          "text": "Illumina HiSeq 4000"
+        },
         "library_construction": "smart-seq2"
       }
     },


### PR DESCRIPTION
These fixes should now let Travis CI tests pass. Changes include:
- Updating reference to biological_macromolecule ontology module for `input_molecule` field
- Adding `input_molecule` field to example process bundle