### PR TITLE
Add disease field for specimen. Fixes #11.

### DIFF
--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -58,6 +58,14 @@
             "comment": "The term organ part is very broadly defined here.",
             "user_friendly": "Organ part"
         },
+        "disease": {
+            "description": "Short description of disease status of the specimen.",
+            "type": "array",
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/disease_ontology.json"
+	        },
+            "user_friendly": "Disease"
+        },
         "state_of_specimen": {
             "description": "State of the specimen at the time of collection/removal.",
             "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/biomaterial/state_of_specimen.json"

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -59,7 +59,7 @@
             "user_friendly": "Organ part"
         },
         "disease": {
-            "description": "Short description of disease status of the specimen. Must be one of 'normal' or one or more disease terms.",
+            "description": "Short description of disease status of the specimen. Can be 'normal' or one or more disease terms.",
             "type": "array",
             "items": {
                 "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/disease_ontology.json"

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -59,7 +59,7 @@
             "user_friendly": "Organ part"
         },
         "disease": {
-            "description": "Short description of disease status of the specimen.",
+            "description": "Short description of disease status of the specimen. Must be one of 'normal' or one or more disease terms.",
             "type": "array",
             "items": {
                 "$ref": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/v5_prototype/json_schema/module/ontology/disease_ontology.json"


### PR DESCRIPTION
We need to allow users to declare that their sample represents a certain disease separate from a disease the organism might have that may or may not be related to the disease of the specimen.