### PR TITLE
V5 prototype remove extra hierarchy from biomaterial types

### DIFF
--- a/json_schema/module/biomaterial/death.json
+++ b/json_schema/module/biomaterial/death.json
@@ -5,8 +5,7 @@
     "additionalProperties": false,
     "required": [
         "$schema",
-    	"cause_of_death",
-        "time_of_death"
+    	"cause_of_death"
     ],
     "title": "death",
     "type": "object",

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://schema.humancellatlas.org/type/biomaterial/cell_line/4.0.0/cell_line.json",
+    "id": "http://schema.humancellatlas.org/type/biomaterial/4.0.0/cell_line.json",
     "description": "Information about the cell line used in the biomaterial",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://schema.humancellatlas.org/type/biomaterial/cell_suspension/4.0.0/cell_suspension.json",
+    "id": "http://schema.humancellatlas.org/type/biomaterial/4.0.0/cell_suspension.json",
     "description": "Information about the cell suspension derived from the collected or cultured specimen",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/biomaterial/organism.json
+++ b/json_schema/type/biomaterial/organism.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://schema.humancellatlas.org/type/biomaterial/organism/4.0.0/organism.json",
+    "id": "http://schema.humancellatlas.org/type/biomaterial/4.0.0/organism.json",
     "description": "Information about the organism from which a specimen was collected.",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/biomaterial/organoid.json
+++ b/json_schema/type/biomaterial/organoid.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://schema.humancellatlas.org/type/biomaterial/organoid/4.0.0/organoid.json",
+    "id": "http://schema.humancellatlas.org/type/biomaterial/4.0.0/organoid.json",
     "description": "Information about an organoid biomaterial.",
     "additionalProperties": false,
     "required": [


### PR DESCRIPTION
Removed the extra /<type>/ in `id` URI for biomaterial types.  Also removed `time_of_death` from required list in death.json. It was removed in v4 but crept back in in v5.