### PR TITLE
Moved insdc_run to sequence_file.json. Fixes #62.

### DIFF
--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -59,6 +59,15 @@
             "type": "integer",
             "example": 51,
             "user_friendly": "Read length"
+        },
+        "insdc_run": {
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Accession must start with DRR, ERR, or SRR.",
+            "type": "array",
+            "items": {
+                "pattern": "^[D|E|S]RR[0-9]+$",
+                "type": "string"
+            },
+            "user_friendly": "INSDC run"
         }
     }
 }

--- a/json_schema/type/process/sequencing/sequencing_process.json
+++ b/json_schema/type/process/sequencing/sequencing_process.json
@@ -61,15 +61,6 @@
             "type": "string",
             "user_friendly": "INSDC experiment"
         },
-        "insdc_run": {
-            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Accession must start with DRR, ERR, or SRR.",
-            "type": "array",
-            "items": {
-                "pattern": "^[D|E|S]RR[0-9]+$",
-                "type": "string"
-            },
-            "user_friendly": "INSDC run"
-        },
         "smartseq2" : {
 	        "description": "Fields specific for SmartSeq2 experiments.",
             "type": "object",


### PR DESCRIPTION
INSDC run IDs are most associated with individual file(s), so this field makes more sense in the sequencing_file json. 