### PR TITLE
Malloryfreeberg bundle schema updates

### DIFF
--- a/json_schema/bundle/biomaterial.json
+++ b/json_schema/bundle/biomaterial.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
     "description": "A schema for a biomaterial bundle.",
     "additionalProperties": false,
     "required": [
         "schema",
         "schema_type"
     ],
-    "title": "biomaterial_bundle",
+    "title": "biomaterial",
     "type": "object",
     "definitions": {
         "biomaterial_ingest": {
@@ -32,20 +32,6 @@
                         { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/organoid" },
                         { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/cell_line" }
                     ]
-                },
-                "derived_from": {
-                    "description": "The biomaterial_id(s) of the biomaterial(s) that this biomaterial was derived from.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "derivation_processes": {
-                    "description": "An array of processes used to derive this biomaterial.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         }
@@ -54,7 +40,7 @@
         "schema": {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/biomaterial_bundle"
+            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/biomaterial"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -68,7 +54,8 @@
                 "biomaterial_bundle"
             ]
         },
-        "biomaterials": {
+        "biomaterial_wrappers": {
+            "description": "An array of biomaterials.",
             "type": "array",
             "items": {
                 "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle#/definitions/biomaterial_ingest"

--- a/json_schema/bundle/biomaterial.json
+++ b/json_schema/bundle/biomaterial.json
@@ -54,7 +54,7 @@
                 "biomaterial_bundle"
             ]
         },
-        "biomaterial_wrappers": {
+        "biomaterials": {
             "description": "An array of biomaterials.",
             "type": "array",
             "items": {

--- a/json_schema/bundle/file.json
+++ b/json_schema/bundle/file.json
@@ -4,7 +4,7 @@
     "description": "A schema for a file bundle.",
     "additionalProperties": false,
     "required": [
-        "$schema",
+        "schema",
         "schema_type"
     ],
     "title": "file",
@@ -26,15 +26,15 @@
                     "description": "Content for any file type entity.",
                     "type": "object",
                     "oneOf": [
-                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/sequence_file" },
-                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/analysis_file" }
+                        { "$ref": "https://schema.humancellatlas.org/type/file/5.0.0/sequence_file" },
+                        { "$ref": "https://schema.humancellatlas.org/type/file/5.0.0/analysis_file" }
                     ]
                 }
             }
         }
     },
     "properties": {
-        "$schema" : {
+        "schema" : {
             "description": "The URL reference to the schema.",
             "type": "string",
             "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/file"
@@ -51,7 +51,7 @@
                 "file_bundle"
             ]
         },
-        "file_wrappers": {
+        "files": {
             "description": "An array of files.",
             "type": "array",
             "items": {

--- a/json_schema/bundle/file.json
+++ b/json_schema/bundle/file.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://schema.humancellatlas.org/bundle/1.0.0/file",
+    "description": "A schema for a file bundle.",
+    "additionalProperties": false,
+    "required": [
+        "$schema",
+        "schema_type"
+    ],
+    "title": "file",
+    "type": "object",
+    "definitions": {
+        "file_ingest": {
+            "required": [
+                "hca_ingest",
+                "content"
+            ],
+            "type": "object",
+            "properties": {
+                "hca_ingest": {
+                    "description": "Core fields added by HCA ingest service",
+                    "type": "object",
+                    "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/ingest_audit"
+                },
+                "content": {
+                    "description": "Content for any file type entity.",
+                    "type": "object",
+                    "oneOf": [
+                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/sequence_file" },
+                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/analysis_file" }
+                    ]
+                }
+            }
+        }
+    },
+    "properties": {
+        "$schema" : {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/file"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "file_bundle"
+            ]
+        },
+        "file_wrappers": {
+            "description": "An array of files.",
+            "type": "array",
+            "items": {
+                "$ref": "https://schema.humancellatlas.org/bundle/1.0.0/biomaterial_bundle#/definitions/file_ingest"
+            }
+        }
+    }
+}

--- a/json_schema/bundle/process.json
+++ b/json_schema/bundle/process.json
@@ -1,20 +1,19 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/process_bundle",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.0/process",
     "description": "A schema for a process bundle.",
     "additionalProperties": false,
     "required": [
         "schema",
         "schema_type"
     ],
-    "title": "process_bundle",
+    "title": "process",
     "type": "object",
     "definitions": {
         "process_ingest": {
             "required": [
                 "hca_ingest",
-                "content",
-                "has_input"
+                "content"
             ],
             "type": "object",
             "properties": {
@@ -35,20 +34,6 @@
                         { "$ref": "https://schema.humancellatlas.org/type/process/sequencing/5.0.0/library_preparation_process" },
                         { "$ref": "https://schema.humancellatlas.org/type/process/sequencing/5.0.0/sequencing_process" }
                     ]
-                },
-                "has_input": {
-                    "description": "The biomaterials or files that this process was performed on.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "has_output": {
-                    "description": "The biomaterials or files that were generated from this process.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         }
@@ -57,7 +42,7 @@
         "schema":  {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/process_bundle"
+            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/process"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -71,7 +56,8 @@
                 "process_bundle"
             ]
         },
-        "processes": {
+        "process_wrappers": {
+            "description": "An array of processes.",
             "type": "array",
             "items": {
                 "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/process_bundle#/definitions/process_ingest"

--- a/json_schema/bundle/process.json
+++ b/json_schema/bundle/process.json
@@ -56,7 +56,7 @@
                 "process_bundle"
             ]
         },
-        "process_wrappers": {
+        "processes": {
             "description": "An array of processes.",
             "type": "array",
             "items": {

--- a/json_schema/bundle/project.json
+++ b/json_schema/bundle/project.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/project_bundle",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.0/project",
     "description": "A schema for a project bundle.",
     "additionalProperties": false,
     "required": [
@@ -9,13 +9,13 @@
         "hca_ingest",
         "content"
     ],
-    "title": "project_bundle",
+    "title": "project",
     "type": "object",
     "properties": {
         "schema": {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern": "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/project_bundle"
+            "pattern": "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/project"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",

--- a/json_schema/bundle/protocol.json
+++ b/json_schema/bundle/protocol.json
@@ -53,7 +53,7 @@
                 "protocol_bundle"
             ]
         },
-        "protocol_wrappers": {
+        "protocols": {
             "description": "An array of protocols.",
             "items": {
                 "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/protocol_bundle#/definitions/protocol_ingest"

--- a/json_schema/bundle/protocol.json
+++ b/json_schema/bundle/protocol.json
@@ -50,7 +50,7 @@
             "description": "The type of the metadata schema entity.",
             "type": "string",
             "enum": [
-                "project_bundle"
+                "protocol_bundle"
             ]
         },
         "protocol_wrappers": {

--- a/json_schema/bundle/protocol.json
+++ b/json_schema/bundle/protocol.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/protocol_bundle",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.0/protocol",
     "description": "A schema for a protocol bundle.",
     "additionalProperties": false,
     "required": [
         "schema",
         "schema_type"
     ],
-    "title": "protocol_bundle",
+    "title": "protocol",
     "type": "object",
     "definitions": {
         "protocol_ingest": {
@@ -31,13 +31,6 @@
                         { "$ref": "https://schema.humancellatlas.org/type/protocol/imaging/5.0.0/imaging_protocol" },
                         { "$ref": "https://schema.humancellatlas.org/type/protocol/sequencing/5.0.0/sequencing_protocol" }
                     ]
-                },
-                "has_process": {
-                    "description": "An array of processes that instantiated this protocol.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         }
@@ -46,7 +39,7 @@
         "schema":  {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/protocol_bundle"
+            "pattern" : "https://schema.humancellatlas.org/bundle/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/protocol"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -60,7 +53,8 @@
                 "project_bundle"
             ]
         },
-        "protocols": {
+        "protocol_wrappers": {
+            "description": "An array of protocols.",
             "items": {
                 "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/protocol_bundle#/definitions/protocol_ingest"
             },

--- a/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle",
+  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
   "schema_version": "5.0.0",
   "schema_type": "biomaterial_bundle",
   "biomaterials": [
@@ -34,6 +34,7 @@
     },
     {
       "hca_ingest": {
+        "schema": "https://schema.humancellatlas.org/bundle/5.0.0/ingest_audit",
         "document_id": "a37dbd93-b93a-4838-a7bb-cd0796b3d9d1",
         "submissionDate": "2017-10-13T09:18:49.422Z",
         "updateDate": "2017-10-13T09:19:40.069Z",
@@ -62,9 +63,7 @@
           "schema": "https://schema.humancellatlas.org/module/ontology/5.0.0/organ_part_ontology",
           "text": "peripheral blood mononuclear cells (PBMCs)"
         }
-      },
-      "derived_from": ["a37dbd93-b93a-4838-a7bb-cd0796b3d9d1"],
-      "derivation_processes": []
+      }
     }
   ]
 }

--- a/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial_bundle",
+  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
   "schema_version": "5.0.0",
   "schema_type": "biomaterial_bundle",
   "biomaterials": [
@@ -70,9 +70,7 @@
           "schema": "https://schema.humancellatlas.org/module/ontology/5.0.0/organ_part_ontology",
           "text": "peripheral blood mononuclear cells (PBMCs)"
         }
-      },
-      "derived_from": ["a37dbd93-b93a-4838-a7bb-cd0796b3d9d1"],
-      "derivation_processes": []
+      }
     }
   ]
 }

--- a/schema_test_files/process/test_pass_process_bundle.json
+++ b/schema_test_files/process/test_pass_process_bundle.json
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/process_bundle",
+  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/process",
   "schema_version": "5.0.0",
   "schema_type": "process_bundle",
   "processes": [
@@ -11,13 +11,6 @@
         "updateDate": "2017-12-16T01:44:24.837Z",
         "document_id": "63688c4a-1280-4eb7-a431-2456f89c3cde"
       },
-      "has_input": [
-        "2896fd1c-e99b-4763-9988-f6093d749240"
-      ],
-      "has_output": [
-        "15cdc9e6-d588-4ab3-8328-6fadaf40a2d1",
-        "fc60c1cf-ffd1-4bdb-b06c-b31896efcd46"
-      ],
       "content": {
         "schema": "https://schema.humancellatlas.org/type/process/biomaterial_collection/5.0.0/dissociation_process",
         "schema_type": "process",
@@ -36,12 +29,6 @@
         "updateDate": "2017-12-16T01:44:24.837Z",
         "document_id": "63688c4a-1280-4eb7-a431-2456f89c3cdf"
       },
-      "has_input": [
-        "2896fd1c-e99b-4763-9988-f6093d749240"
-      ],
-      "has_output": [
-        "fc60c1cf-ffd1-4bdb-b06c-b31896efcd46"
-      ],
       "content": {
         "schema": "https://schema.humancellatlas.org/type/process/sequencing/5.0.0/library_preparation_process",
         "schema_type": "process",
@@ -66,12 +53,6 @@
         "updateDate": "2017-12-16T01:44:24.837Z",
         "document_id": "63688c4a-1280-4eb7-a431-2456f89c3cdf"
       },
-      "has_input": [
-        "2896fd1c-e99b-4763-9988-f6093d749240"
-      ],
-      "has_output": [
-        "fc60c1cf-ffd1-4bdb-b06c-b31896efcd46"
-      ],
       "content": {
         "schema": "https://schema.humancellatlas.org/type/process/sequencing/5.0.0/sequencing_process",
         "schema_type": "process",

--- a/schema_test_files/project/test_pass_project_bundle.json
+++ b/schema_test_files/project/test_pass_project_bundle.json
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/project_bundle",
+  "schema": "https://schema.humancellatlas.org/bundle/5.0.0/project",
   "schema_version": "5.0.0",
   "schema_type": "project_bundle",
   "content": {

--- a/src/json_examples_validate_against_schema.py
+++ b/src/json_examples_validate_against_schema.py
@@ -73,8 +73,8 @@ if not validate(sv, b1):
 # Specific bundle tests follow
 '''
 # Testing valid biomaterial bundle example
-print('\nValidating bundle/biomaterial_bundle.json schema')
-sv = get_validator('bundle/biomaterial_bundle.json', base_uri)
+print('\nValidating bundle/biomaterial.json schema')
+sv = get_validator('bundle/biomaterial.json', base_uri)
 print('Validating biomaterial/test_pass_biomaterial_bundle.json JSON against schema')
 b1 = get_json_from_file('../schema_test_files/biomaterial/test_pass_biomaterial_bundle.json')
 if not validate(sv, b1):
@@ -82,24 +82,24 @@ if not validate(sv, b1):
 
 # Testing invalid biomaterial bundle example
 # Bundle is missing hca_ingest property in one of the biomaterials
-print('\nValidating bundle/biomaterial_bundle.json schema')
-sv = get_validator('bundle/biomaterial_bundle.json', base_uri)
+print('\nValidating bundle/biomaterial.json schema')
+sv = get_validator('bundle/biomaterial.json', base_uri)
 print('Validating biomaterial/test_fail_biomaterial_bundle.json JSON against schema\n(This should fail, missing hca_ingest)')
 b2 = get_json_from_file('../schema_test_files/biomaterial/test_fail_biomaterial_bundle.json')
 if validate(sv, b2):
     status_flag = False
 
 # Testing valid project bundle example
-print('\nValidating bundle/project_bundle.json schema')
-sv = get_validator('bundle/project_bundle.json', base_uri)
+print('\nValidating bundle/project.json schema')
+sv = get_validator('bundle/project.json', base_uri)
 print('Validating project/test_pass_project_bundle.json JSON against schema')
 b1 = get_json_from_file('../schema_test_files/project/test_pass_project_bundle.json')
 if not validate(sv, b1):
     status_flag = False
 
 # Testing valid process bundle example
-print('\nValidating bundle/process_bundle.json schema')
-sv = get_validator('bundle/process_bundle.json', base_uri)
+print('\nValidating bundle/process.json schema')
+sv = get_validator('bundle/process.json', base_uri)
 print('Validating process/test_pass_process_bundle.json JSON against schema')
 b1 = get_json_from_file('../schema_test_files/process/test_pass_process_bundle.json')
 if not validate(sv, b1):

--- a/src/json_examples_validate_against_schema.py
+++ b/src/json_examples_validate_against_schema.py
@@ -71,7 +71,7 @@ if not validate(sv, b1):
     status_flag = False
 
 # Specific bundle tests follow
-'''
+
 # Testing valid biomaterial bundle example
 print('\nValidating bundle/biomaterial.json schema')
 sv = get_validator('bundle/biomaterial.json', base_uri)
@@ -104,7 +104,7 @@ print('Validating process/test_pass_process_bundle.json JSON against schema')
 b1 = get_json_from_file('../schema_test_files/process/test_pass_process_bundle.json')
 if not validate(sv, b1):
     status_flag = False
-'''
+
 # If any of the validate() calls fail, set exit status to 1.
 # Failed validate() calls on things that are supposed to fail will not affect exit status.
 # Without the following line, failed validate() will result in exit status 0, which is not desirable.


### PR DESCRIPTION
Updates to bundle schemas for v5.0.0 include:
- Changing schema names and title to remove "_bundle" part
- Removing all linking fields (e.g. derived_from)
- Adding a file bundle schema
- Updating example bundle JSON