### PR TITLE
Malloryfreeberg bug fix issue217

### DIFF
--- a/json_schema/bundle/biomaterial.json
+++ b/json_schema/bundle/biomaterial.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.1/biomaterial",
     "description": "A schema for a biomaterial bundle.",
     "additionalProperties": false,
     "required": [
@@ -30,7 +30,7 @@
                         { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/specimen_from_organism" },
                         { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/cell_suspension" },
                         { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/organoid" },
-                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/cell_line" }
+                        { "$ref": "https://schema.humancellatlas.org/type/biomaterial/5.0.1/cell_line" }
                     ]
                 }
             }
@@ -58,7 +58,7 @@
             "description": "An array of biomaterials.",
             "type": "array",
             "items": {
-                "$ref": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial#/definitions/biomaterial_ingest"
+                "$ref": "https://schema.humancellatlas.org/bundle/5.0.1/biomaterial#/definitions/biomaterial_ingest"
             }
         }
     }

--- a/json_schema/bundle/project.json
+++ b/json_schema/bundle/project.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.0.0/project",
+    "id": "https://schema.humancellatlas.org/bundle/5.0.1/project",
     "description": "A schema for a project bundle.",
     "additionalProperties": false,
     "required": [
@@ -37,7 +37,7 @@
         "content": {
             "description": "Content for a project type entity.",
             "type": "object",
-            "$ref": "https://schema.humancellatlas.org/type/project/5.0.0/project"
+            "$ref": "https://schema.humancellatlas.org/type/project/5.0.1/project"
         }
     }
 }

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -6,7 +6,7 @@
     "required": [
         "describedBy",
         "authors",
-        "title"
+        "publication_title"
     ],
     "title": "publication",
     "type": "object",

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/module/project/5.0.0/publication",
+    "id": "https://schema.humancellatlas.org/module/project/5.0.1/publication",
     "description": "Information about a journal article, book, web page, or other external available documentation on a project.",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -104,7 +104,7 @@
             "description": "One or more publications in which the cell line creation was cited.",
             "type": "array",
             "items": {
-                "$ref": "https://schema.humancellatlas.org/module/project/5.0.0/publication"
+                "$ref": "https://schema.humancellatlas.org/module/project/5.0.1/publication"
             },
             "user_friendly": "Publications"
         }

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/cell_line",
+    "id": "https://schema.humancellatlas.org/type/biomaterial/5.0.1/cell_line",
     "description": "Information about the cell line used in the biomaterial",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/type/project/5.0.0/project",
+    "id": "https://schema.humancellatlas.org/type/project/5.0.1/project",
     "description": "A project contains information about the overall project.",
     "additionalProperties": false,
     "required": [

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -54,7 +54,7 @@
     	    "description": "A list of publications resulting from this project.",
             "type": "array",
             "items": {
-                "$ref": "https://schema.humancellatlas.org/module/project/5.0.0/publication"
+                "$ref": "https://schema.humancellatlas.org/module/project/5.0.1/publication"
             }
         },
         "insdc_project": {

--- a/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_fail_biomaterial_bundle.json
@@ -1,5 +1,5 @@
 {
-  "describedBy": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
+  "describedBy": "https://schema.humancellatlas.org/bundle/5.0.1/biomaterial",
   "schema_version": "5.0.0",
   "schema_type": "biomaterial_bundle",
   "biomaterials": [

--- a/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
+++ b/schema_test_files/biomaterial/test_pass_biomaterial_bundle.json
@@ -1,5 +1,5 @@
 {
-  "describedBy": "https://schema.humancellatlas.org/bundle/5.0.0/biomaterial",
+  "describedBy": "https://schema.humancellatlas.org/bundle/5.0.1/biomaterial",
   "schema_version": "5.0.0",
   "schema_type": "biomaterial_bundle",
   "biomaterials": [

--- a/schema_test_files/project/test_fail_project_0.json
+++ b/schema_test_files/project/test_fail_project_0.json
@@ -1,5 +1,5 @@
 {
-  "describedBy": "https://schema.humancellatlas.org/type/project/5.0.0/project",
+  "describedBy": "https://schema.humancellatlas.org/type/project/5.0.1/project",
   "schema_version": "5.0.0",
   "schema_type": "project",
   "project_core": {

--- a/schema_test_files/project/test_pass_project_0.json
+++ b/schema_test_files/project/test_pass_project_0.json
@@ -1,5 +1,5 @@
 {
-  "describedBy": "https://schema.humancellatlas.org/type/project/5.0.0/project",
+  "describedBy": "https://schema.humancellatlas.org/type/project/5.0.1/project",
   "schema_version": "5.0.0",
   "schema_type": "project",
   "project_core": {

--- a/schema_test_files/project/test_pass_project_bundle.json
+++ b/schema_test_files/project/test_pass_project_bundle.json
@@ -3,7 +3,7 @@
   "schema_version": "5.0.0",
   "schema_type": "project_bundle",
   "content": {
-    "describedBy": "https://schema.humancellatlas.org/type/project/5.0.0/project",
+    "describedBy": "https://schema.humancellatlas.org/type/project/5.0.1/project",
     "schema_version" : "5.0.0",
     "schema_type": "project",
     "project_core": {


### PR DESCRIPTION
As referenced in Issue #217, `title` should be `publication_title` in the list of required fields in the `publication` module. This change is a patch because it is a bug fix. References to this module in `cell_line.json` and `project.json` were also update to reflect the version change.  