### PR TITLE
Analysis json hackathon

### DIFF
--- a/json_schema/type/process/analysis/analysis_process.json
+++ b/json_schema/type/process/analysis/analysis_process.json
@@ -12,7 +12,6 @@
         "input_bundles",
         "reference_bundle",
         "analysis_run_type",
-        "metadata_schema",
         "tasks",
         "inputs",
         "outputs"

--- a/json_schema/type/process/analysis/analysis_process.json
+++ b/json_schema/type/process/analysis/analysis_process.json
@@ -171,11 +171,6 @@
                 "run",
                 "copy-forward"
             ]
-        },
-        "metadata_schema": {
-            "description": "The version of the metadata schemas used for the JSON files.",
-            "type": "string",
-            "pattern" : "[0-9]{1,}.[0-9]{1,}.[0-9]{1,}"
         }
     }
 }


### PR DESCRIPTION
As part of the review of analysis json, we identified that metadata_schema is no longer required as each component schema (eg analysis_file) should be self-describing. metadata_schema was therefore removed.