### PR TITLE
biological_macromolecule_ontology.json has badly formatted array for ontologies

### DIFF
--- a/json_schema/module/ontology/biological_macromolecule_ontology.json
+++ b/json_schema/module/ontology/biological_macromolecule_ontology.json
@@ -28,7 +28,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:chebi, obo:efo, obo:obi"],
+                "ontologies" : ["obo:chebi", "obo:efo", "obo:obi"],
                 "classes": ["EFO:0004446"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,


### PR DESCRIPTION
Ontologies should be a list, but it was a list inside a single string. 

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->
Detected when programming against the schema 

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->
Fixed the formatting of the allowable ontologies for the biological_macromolecule_ontology.json schema
