### PR TITLE
Patch release to fix incorrect self-reference in process bundle json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
+### [bundle/process.json - v5.2.1] - 2018-03-15
+### Changed
+Bug fix to make reference bundle schema reference its own definition with correct version
+
 ### [bundle/reference.json - v1.0.1] - 2018-03-15
 ### Changed
 Bug fix to make reference bundle schema use the correct dependent version numbers

--- a/json_schema/bundle/process.json
+++ b/json_schema/bundle/process.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://schema.humancellatlas.org/bundle/5.2.0/process",
+    "id": "https://schema.humancellatlas.org/bundle/5.2.1/process",
     "description": "A schema for a process bundle.",
     "additionalProperties": false,
     "required": [
@@ -61,7 +61,7 @@
             "description": "An array of processes.",
             "type": "array",
             "items": {
-                "$ref": "https://schema.humancellatlas.org/bundle/5.1.0/process#/definitions/process_ingest"
+                "$ref": "https://schema.humancellatlas.org/bundle/5.2.1/process#/definitions/process_ingest"
             }
         }
     }


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->

Release notes
### [bundle/process.json - v5.2.1] - 2018-03-15
### Changed
Bug fix to make reference bundle schema reference its own definition with correct version
