### PR TITLE
Added kit titer field to purchased reagents module

### DIFF
--- a/json_schema/module/process/purchased_reagents.json
+++ b/json_schema/module/process/purchased_reagents.json
@@ -46,6 +46,12 @@
             "format": "date",
             "example": "2018-01-31",
             "user_friendly": "Expiry date"
-        }
+        },
+	"kit_titer": {
+	    "description": "Appropriate titer and volume recommendations found in each kit's Certificate of Analysis.",
+	    "type": "string",
+	    "example": "Titer: Specification is 3.0x10 7 ",
+	    "user_friendly": "Kit Titer"
+	    }
 	}
 }


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->
Which schema would you like to be changed?

/json_schema/module/process/purchased_reagents.json

What new field(s) need to be added?

Added Kit titer field

Details for requesting new field(s) outlined below
Field name (required): kit_titer

Field description (required): Appropriate titer and volume recommendations found in each kit's Certificate of Analysis. 

Whether the field should be optional or required (required): Optional

An example of valid value for this field (optional): Titer: Specification is 3.0x10 7 − 9.0x107 Cell Infectious Units/mL

Why is the change needed?
This is needed for the induction process to help understand the virus and how it works in the kit.