### PR TITLE
Added missing type: string to nutritional_state field.

### DIFF
--- a/json_schema/module/biomaterial/medical_history.json
+++ b/json_schema/module/biomaterial/medical_history.json
@@ -28,6 +28,7 @@
         },
         "nutritional_state": {
             "description": "Should be one of normal, fasting, or feeding tube removed.",
+            "type": "string",
             "enum": [
                 "normal",
                 "fasting",


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->

**Fixed**
This changes fixes the nutritional_state field in the medical_history module that was missing `"type": "string"` to declare this field as a string. This is a bug fix (i.e. patch change) to the `json_schema/module/biomaterial/medical_history.json` and should increment the patch version by 1.

