### PR TITLE
Process-protocol move: enrichment process

### DIFF
--- a/json_schema/bundle/process.json
+++ b/json_schema/bundle/process.json
@@ -28,7 +28,6 @@
                         { "$ref": "type/process/analysis/analysis_process.json" },
                         { "$ref": "type/process/biomaterial_collection/collection_process.json" },
                         { "$ref": "type/process/biomaterial_collection/dissociation_process.json" },
-                        { "$ref": "type/process/biomaterial_collection/enrichment_process.json" },
                         { "$ref": "type/process/imaging/imaging_process.json" },
                         { "$ref": "type/process/sequencing/library_preparation_process.json" },
                         { "$ref": "type/process/sequencing/sequencing_process.json" },

--- a/json_schema/bundle/protocol.json
+++ b/json_schema/bundle/protocol.json
@@ -27,6 +27,7 @@
                     "oneOf": [
                         { "$ref": "type/protocol/analysis/analysis_protocol.json" },
                         { "$ref": "type/protocol/biomaterial/biomaterial_collection_protocol.json" },
+                        { "$ref": "type/protocol/biomaterial_collection/enrichment_protocol.json" },
                         { "$ref": "type/protocol/imaging/imaging_protocol.json" },
                         { "$ref": "type/protocol/sequencing/sequencing_protocol.json" },
                         { "$ref": "type/protocol/protocol.json" }

--- a/json_schema/type/protocol/biomaterial_collection/enrichment_protocol.json
+++ b/json_schema/type/protocol/biomaterial_collection/enrichment_protocol.json
@@ -1,20 +1,20 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "Process by which one biomaterial was produced from another biomaterial to favor a feature or characteristic of interest.",
+    "description": "protocol by which one biomaterial was produced from another biomaterial to favor a feature or characteristic of interest.",
     "additionalProperties": false,
     "required": [
         "describedBy",
         "schema_type",
-        "process_core",
+        "protocol_core",
         "enrichment_method"
     ],
-    "title": "enrichment_process",
+    "title": "enrichment_protocol",
     "type": "object",
     "properties": {
         "describedBy":  {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "https://schema.humancellatlas.org/type/process/biomaterial_collection/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/enrichment_process"
+            "pattern" : "https://schema.humancellatlas.org/type/protocol/biomaterial_collection/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/enrichment_protocol"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -26,13 +26,13 @@
             "description": "The type of the metadata schema entity.",
             "type": "string",
             "enum": [
-                "process"
+                "protocol"
             ]
         },
-         "process_core" : {
-            "description": "Core process-level information.",
+         "protocol_core" : {
+            "description": "Core protocol-level information.",
              "type": "object",
-            "$ref": "core/process/process_core.json"
+            "$ref": "core/protocol/protocol_core.json"
         },
         "enrichment_method": {
             "description": "The method by which enrichment was achieved.",
@@ -68,11 +68,11 @@
             "minimum": 0.01,
             "user_friendly": "Maximum size selected"
         },
-         "process_type": {
-            "description": "The type of process. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002694.",
+         "protocol_type": {
+            "description": "The type of protocol. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002694.",
             "type": "object",
-            "$ref": "module/ontology/process_type_ontology.json",
-            "user_friendly": "Process type"
+            "$ref": "module/ontology/protocol_type_ontology.json",
+            "user_friendly": "protocol type"
         }
     }
 }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -38,8 +38,7 @@
         },
         "biomaterial_collection": {
           "collection_process": "5.1.0",
-          "dissociation_process": "5.1.0",
-          "enrichment_process": "5.1.0"
+          "dissociation_process": "5.1.0"
         },
         "imaging": {
           "imaging_process": "5.1.0"
@@ -57,8 +56,9 @@
         "analysis": {
           "analysis_protocol": "5.1.0"
         },
-        "biomaterial": {
-          "biomaterial_collection_protocol": "5.1.0"
+        "biomaterial_collection": {
+          "collection_protocol": "6.0.0",
+          "enrichment_protocol": "1.0.0"
         },
         "imaging": {
           "imaging_protocol": "5.1.0"
@@ -118,7 +118,7 @@
       "links": "1.0.0",
       "process": "5.2.1",
       "project": "5.1.0",
-      "protocol": "5.1.0",
+      "protocol": "6.0.0",
       "reference": "1.0.1",
       "submission": "5.1.0"
     }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -116,7 +116,7 @@
       "file": "1.0.0",
       "ingest_audit": "5.1.0",
       "links": "1.0.0",
-      "process": "5.2.1",
+      "process": "6.0.0",
       "project": "5.1.0",
       "protocol": "6.0.0",
       "reference": "1.0.1",


### PR DESCRIPTION
This change is part of the wider effort to move process fields to protocols. Changes in this PR are detailed below.

### Release notes 
renamed protocol/biomaterial to protocol/biomaterial_collection to reflect current process hierarchy, and updated all relevant references (bundles etc)

created enrichment_protocol and moved all fields from enrichment_process to enrichment_protocol

renamed all process* to protocol* as appropriate

deleted enrichment_process and all relevant references

