### PR TITLE
Process-protocol move: library preparation

### DIFF
--- a/json_schema/bundle/process.json
+++ b/json_schema/bundle/process.json
@@ -30,7 +30,6 @@
                         { "$ref": "type/process/biomaterial_collection/dissociation_process.json" },
                         { "$ref": "type/process/biomaterial_collection/enrichment_process.json" },
                         { "$ref": "type/process/imaging/imaging_process.json" },
-                        { "$ref": "type/process/sequencing/library_preparation_process.json" },
                         { "$ref": "type/process/sequencing/sequencing_process.json" },
                         { "$ref": "type/process/process.json"}
                     ]

--- a/json_schema/bundle/protocol.json
+++ b/json_schema/bundle/protocol.json
@@ -28,6 +28,7 @@
                         { "$ref": "type/protocol/analysis/analysis_protocol.json" },
                         { "$ref": "type/protocol/biomaterial/biomaterial_collection_protocol.json" },
                         { "$ref": "type/protocol/imaging/imaging_protocol.json" },
+                        { "$ref": "type/protocol/sequencing/library_preparation_protocol.json" },
                         { "$ref": "type/protocol/sequencing/sequencing_protocol.json" },
                         { "$ref": "type/protocol/protocol.json" }
                     ]

--- a/json_schema/type/protocol/sequencing/library_preparation_protocol.json
+++ b/json_schema/type/protocol/sequencing/library_preparation_protocol.json
@@ -5,19 +5,19 @@
     "required": [
         "describedBy",
         "schema_type",
-        "process_core",
+        "protocol_core",
         "end_bias",
         "library_construction_approach",
         "strand",
         "input_nucleic_acid_molecule"
     ],
-    "title": "library_preparation_process",
+    "title": "library_preparation_protocol",
     "type": "object",
     "properties": {
          "describedBy":  {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "https://schema.humancellatlas.org/type/process/sequencing/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/library_preparation_process"
+            "pattern" : "https://schema.humancellatlas.org/type/protocol/sequencing/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/library_preparation_protocol"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -29,13 +29,13 @@
             "description": "The type of the metadata schema entity.",
             "type": "string",
             "enum": [
-                "process"
+                "protocol"
             ]
         },
-        "process_core" : {
-            "description": "Core process-level information.",
+        "protocol_core" : {
+            "description": "Core protocol-level information.",
             "type": "object",
-            "$ref": "core/process/process_core.json"
+            "$ref": "core/protocol/protocol_core.json"
         },
         "cell_barcode": {
             "description": "Information about cell identifier barcode.",
@@ -137,11 +137,11 @@
             "$ref": "module/process/sequencing/barcode.json",
             "user_friendly": "UMI barcode"
         },
-        "process_type": {
-            "description": "The type of process. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002694.",
+        "protocol_type": {
+            "description": "The type of protocol. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002694.",
             "type": "object",
-            "$ref": "module/ontology/process_type_ontology.json",
-            "user_friendly": "Process type"
+            "$ref": "module/ontology/protocol_type_ontology.json",
+            "user_friendly": "protocol type"
         }
     }
 }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -45,7 +45,6 @@
           "imaging_process": "5.1.0"
         },
          "sequencing": {
-          "library_preparation_process": "5.1.0",
           "sequencing_process": "5.1.0"
         }
       },
@@ -63,7 +62,8 @@
         "imaging": {
           "imaging_protocol": "5.1.0"
         },
-          "sequencing": {
+        "sequencing": {
+          "library_preparation_protocol": "1.0.0",
           "sequencing_protocol": "5.1.0"
         }
       }
@@ -116,9 +116,9 @@
       "file": "1.0.0",
       "ingest_audit": "5.1.0",
       "links": "1.0.0",
-      "process": "5.2.1",
+      "process": "6.0.0",
       "project": "5.1.0",
-      "protocol": "5.1.0",
+      "protocol": "6.0.0",
       "reference": "1.0.1",
       "submission": "5.1.0"
     }


### PR DESCRIPTION
This change is part of the wider effort to move process fields to protocols. Changes in this PR are detailed below.

### Release notes 

created library_preparation_protocol and moved all fields from library_preparation_process to library_preparation_protocol

renamed all process* to protocol* as appropriate

deleted library_preparation_process and all relevant references

updated version numbers

