### PR TITLE
Process-protocol move: sequencing

### DIFF
--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -67,6 +67,11 @@
                 "type": "string"
             },
             "user_friendly": "INSDC run"
+        },
+         "smartseq2" : {
+	        "description": "Fields specific for SmartSeq2 experiments.",
+            "type": "object",
+            "$ref": "module/process/sequencing/smartseq2.json"
         }
     }
 }

--- a/json_schema/type/process/sequencing/sequencing_process.json
+++ b/json_schema/type/process/sequencing/sequencing_process.json
@@ -5,9 +5,7 @@
     "required": [
         "describedBy",
         "schema_type",
-        "process_core",
-        "instrument_manufacturer_model",
-        "paired_ends"
+        "process_core"
     ],
     "title": "sequencing_process",
     "type": "object",
@@ -35,35 +33,11 @@
             "type": "object",
             "$ref": "core/process/process_core.json"
         },
-        "instrument_manufacturer_model": {
-            "description": "The manufacturer and model of the sequencer used. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000548.",
-            "type": "object",
-            "$ref": "module/ontology/instrument_ontology.json",
-            "example": "Illumina HiSeq 4000",
-            "user_friendly": "Instrument manufacturer and model"
-        },
-        "local_machine_name": {
-            "description": "Local name for the particular machine on which the biomaterial was sequenced.",
-            "type": "string",
-            "user_friendly": "Local machine name"
-        },
-        "paired_ends": {
-            "description": "Was a paired-end sequencing strategy used? Must be either yes or no.",
-            "type": "boolean",
-            "example": "yes",
-            "comment": "If 10x, then put no.",
-            "user_friendly": "Paired ends?"
-        },
         "insdc_experiment": {
             "description": "An INSDC (International Nucleotide Sequence Database Collaboration) experiment accession. Accession must start with DRX, ERX, or SRX.",
             "pattern": "^[D|E|S]RX[0-9]+$",
             "type": "string",
             "user_friendly": "INSDC experiment"
-        },
-        "smartseq2" : {
-	        "description": "Fields specific for SmartSeq2 experiments.",
-            "type": "object",
-            "$ref": "module/process/sequencing/smartseq2.json"
         },
         "process_type": {
             "description": "The type of process. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002694.",

--- a/json_schema/type/protocol/sequencing/sequencing_protocol.json
+++ b/json_schema/type/protocol/sequencing/sequencing_protocol.json
@@ -5,7 +5,9 @@
     "required": [
         "describedBy",
         "schema_type",
-        "protocol_core"
+        "protocol_core",
+        "instrument_manufacturer_model",
+        "paired_ends"
     ],
     "title": "sequencing_protocol",
     "type": "object",
@@ -32,6 +34,25 @@
             "description": "Core protocol-level information.",
             "type": "object",
             "$ref": "core/protocol/protocol_core.json"
+        },
+         "instrument_manufacturer_model": {
+            "description": "The manufacturer and model of the sequencer used. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000548.",
+            "type": "object",
+            "$ref": "module/ontology/instrument_ontology.json",
+            "example": "Illumina HiSeq 4000",
+            "user_friendly": "Instrument manufacturer and model"
+        },
+        "local_machine_name": {
+            "description": "Local name for the particular machine on which the biomaterial was sequenced.",
+            "type": "string",
+            "user_friendly": "Local machine name"
+        },
+        "paired_ends": {
+            "description": "Was a paired-end sequencing strategy used? Must be either yes or no.",
+            "type": "boolean",
+            "example": "yes",
+            "comment": "If 10x, then put no.",
+            "user_friendly": "Paired ends?"
         },
         "protocol_type": {
             "description": "The type of protocol. Must be a child term of https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FOBI_0000272.",

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -29,7 +29,7 @@
       "file":{
         "analysis_file": "5.1.0",
         "reference_file": "1.0.1",
-        "sequence_file": "5.1.0"
+        "sequence_file": "6.0.0"
       },
       "process":{
         "process": "1.0.0",
@@ -46,7 +46,7 @@
         },
          "sequencing": {
           "library_preparation_process": "5.1.0",
-          "sequencing_process": "5.1.0"
+          "sequencing_process": "6.0.0"
         }
       },
       "project":{
@@ -113,12 +113,12 @@
     },
     "bundle": {
       "biomaterial": "5.1.0",
-      "file": "1.0.0",
+      "file": "2.0.0",
       "ingest_audit": "5.1.0",
       "links": "1.0.0",
-      "process": "5.2.1",
+      "process": "6.0.0",
       "project": "5.1.0",
-      "protocol": "5.1.0",
+      "protocol": "6.0.0",
       "reference": "1.0.1",
       "submission": "5.1.0"
     }

--- a/schema_test_files/protocol/test_pass_sequencing_protocol.json
+++ b/schema_test_files/protocol/test_pass_sequencing_protocol.json
@@ -1,0 +1,11 @@
+{
+  "describedBy": "https://schema.humancellatlas.org/type/protocol/sequencing/5.1.0/sequencing_protocol",
+  "schema_type": "protocol",
+  "protocol_core": {
+    "protocol_id": "seq_protocol_1"
+  },
+  "paired_ends": true,
+  "instrument_manufacturer_model": {
+    "text": "Illumina HiSeq 4000"
+  }
+}

--- a/src/json_examples_validate_against_schema.py
+++ b/src/json_examples_validate_against_schema.py
@@ -63,10 +63,10 @@ if validate(sv, s2):
     status_flag = False
 
 # Testing valid process example
-print('\nValidating type/process/sequencing/sequencing_process.json schema')
-sv = get_validator('type/process/sequencing/sequencing_process.json', base_uri)
-print('Validating process/test_pass_sequencing_process.json JSON against schema')
-b1 = get_json_from_file('../schema_test_files/process/test_pass_sequencing_process.json')
+print('\nValidating type/protocol/sequencing/sequencing_protocol.json schema')
+sv = get_validator('type/protocol/sequencing/sequencing_protocol.json', base_uri)
+print('Validating protocol/test_pass_sequencing_protocol.json JSON against schema')
+b1 = get_json_from_file('../schema_test_files/protocol/test_pass_sequencing_protocol.json')
 if not validate(sv, b1):
     status_flag = False
 


### PR DESCRIPTION
This change is part of the wider effort to move process fields to protocols. Changes in this PR are detailed below.

### Release notes 

moved all relevant fields from sequencing_process to sequencing_protocol
did not delete sequencing_process as insdc_experiment can't be moved to process
moved smartseq2 module reference to sequencing_file
updated relevant bundle references and version numbers
updated tests and test files

