### PR TITLE
Dw species ontology fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [module/ontology/species_ontology.json - v5.1.1] - 2018-05-18
+### Changed
+Bug fix to make ontology validation work - root species ontology node changed from "NCBITaxon:131567" to ["OBI:0100026","NCBITaxon:2759"] to reflect usage in HCAO. Patch update to referencing biomaterials and bundles.
+
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [bundle/process.json - v5.2.1] - 2018-03-15

--- a/json_schema/module/ontology/species_ontology.json
+++ b/json_schema/module/ontology/species_ontology.json
@@ -26,8 +26,8 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:NCBITaxon"],
-                "classes": ["NCBITaxon:131567"],
+                "ontologies" : ["obo:NCBITaxon", "obo:efo"],
+                "classes": ["OBI:0100026", "NCBITaxon:2759"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,126 +1,125 @@
 {
-  "last_update_date": "2018-04-24T11:34:00Z",
-  "version_numbers": {
-    "core": {
-      "biomaterial":{
-        "biomaterial_core": "5.1.0"
-      },
-      "file":{
-        "file_core": "5.1.0"
-      },
-      "process":{
-        "process_core": "5.1.0"
-      },
-      "project":{
-        "project_core": "5.1.0"
-      },
-      "protocol":{
-        "protocol_core": "5.1.0"
-      }
-    },
-    "type": {
-      "biomaterial":{
-        "cell_line": "5.1.0",
-        "cell_suspension": "5.1.0",
-        "donor_organism": "5.1.0",
-        "organoid": "5.1.0",
-        "specimen_from_organism": "5.1.0"
-      },
-      "file":{
-        "analysis_file": "5.1.0",
-        "reference_file": "1.0.1",
-        "sequence_file": "5.1.0"
-      },
-      "process":{
-        "process": "1.0.0",
-        "analysis": {
-          "analysis_process": "5.1.0"
+    "last_update_date": "2018-05-18T12:40:31Z",
+    "version_numbers": {
+        "bundle": {
+            "biomaterial": "5.1.1",
+            "file": "1.0.0",
+            "ingest_audit": "5.1.0",
+            "links": "1.0.0",
+            "process": "5.2.1",
+            "project": "5.1.0",
+            "protocol": "5.1.0",
+            "reference": "1.0.2",
+            "submission": "5.1.0"
         },
-        "biomaterial_collection": {
-          "collection_process": "5.1.0",
-          "dissociation_process": "5.1.0",
-          "enrichment_process": "5.1.0"
+        "core": {
+            "biomaterial": {
+                "biomaterial_core": "5.1.0"
+            },
+            "file": {
+                "file_core": "5.1.0"
+            },
+            "process": {
+                "process_core": "5.1.0"
+            },
+            "project": {
+                "project_core": "5.1.0"
+            },
+            "protocol": {
+                "protocol_core": "5.1.0"
+            }
         },
-        "imaging": {
-          "imaging_process": "5.1.0"
+        "module": {
+            "biomaterial": {
+                "cell_morphology": "5.1.0",
+                "death": "5.1.0",
+                "familial_relationship": "5.1.0",
+                "growth_conditions": "5.1.0",
+                "homo_sapiens_specific": "5.1.0",
+                "medical_history": "5.1.0",
+                "mus_musculus_specific": "5.1.0",
+                "preservation_storage": "5.1.0",
+                "state_of_specimen": "5.1.0"
+            },
+            "ontology": {
+                "biological_macromolecule_ontology": "5.1.0",
+                "cell_cycle_ontology": "5.1.0",
+                "cell_type_ontology": "5.1.0",
+                "development_stage_ontology": "5.1.0",
+                "disease_ontology": "5.1.0",
+                "ethnicity_ontology": "5.1.0",
+                "instrument_ontology": "5.1.0",
+                "length_unit_ontology": "5.1.0",
+                "mass_unit_ontology": "5.1.0",
+                "organ_ontology": "5.1.0",
+                "organ_part_ontology": "5.1.0",
+                "process_type_ontology": "5.1.0",
+                "protocol_type_ontology": "5.1.0",
+                "species_ontology": "5.1.1",
+                "strain_ontology": "5.1.0",
+                "time_unit_ontology": "5.1.0"
+            },
+            "process": {
+                "purchased_reagents": "5.1.0",
+                "sequencing": {
+                    "barcode": "5.1.0",
+                    "smartseq2": "5.1.0"
+                }
+            },
+            "project": {
+                "contact": "5.1.0",
+                "publication": "5.1.0"
+            }
         },
-         "sequencing": {
-          "library_preparation_process": "5.1.0",
-          "sequencing_process": "5.1.0"
+        "type": {
+            "biomaterial": {
+                "cell_line": "5.1.1",
+                "cell_suspension": "5.1.1",
+                "donor_organism": "5.1.1",
+                "organoid": "5.1.1",
+                "specimen_from_organism": "5.1.1"
+            },
+            "file": {
+                "analysis_file": "5.1.0",
+                "reference_file": "1.0.2",
+                "sequence_file": "5.1.0"
+            },
+            "process": {
+                "analysis": {
+                    "analysis_process": "5.1.0"
+                },
+                "biomaterial_collection": {
+                    "collection_process": "5.1.0",
+                    "dissociation_process": "5.1.0",
+                    "enrichment_process": "5.1.0"
+                },
+                "imaging": {
+                    "imaging_process": "5.1.0"
+                },
+                "process": "1.0.0",
+                "sequencing": {
+                    "library_preparation_process": "5.1.0",
+                    "sequencing_process": "5.1.0"
+                }
+            },
+            "project": {
+                "project": "5.1.0"
+            },
+            "protocol": {
+                "analysis": {
+                    "analysis_protocol": "5.1.0"
+                },
+                "biomaterial": {
+                    "biomaterial_collection_protocol": "5.1.0"
+                },
+                "imaging": {
+                    "imaging_protocol": "5.1.0"
+                },
+                "protocol": "5.1.0",
+                "sequencing": {
+                    "sequencing_protocol": "5.1.0"
+                }
+            }
         }
-      },
-      "project":{
-        "project": "5.1.0"
-      },
-      "protocol":{
-        "protocol": "5.1.0",
-        "analysis": {
-          "analysis_protocol": "5.1.0"
-        },
-        "biomaterial": {
-          "biomaterial_collection_protocol": "5.1.0"
-        },
-        "imaging": {
-          "imaging_protocol": "5.1.0"
-        },
-          "sequencing": {
-          "sequencing_protocol": "5.1.0"
-        }
-      }
-    },
-    "module": {
-      "biomaterial": {
-        "cell_morphology": "5.1.0",
-        "death": "5.1.0",
-        "familial_relationship": "5.1.0",
-        "growth_conditions": "5.1.0",
-        "homo_sapiens_specific": "5.1.0",
-        "medical_history": "5.1.0",
-        "mus_musculus_specific": "5.1.0",
-        "preservation_storage": "5.1.0",
-        "state_of_specimen": "5.1.0"
-      },
-      "ontology": {
-        "biological_macromolecule_ontology": "5.1.0",
-        "cell_cycle_ontology": "5.1.0",
-        "cell_type_ontology": "5.1.0",
-        "development_stage_ontology": "5.1.0",
-        "disease_ontology": "5.1.0",
-        "ethnicity_ontology": "5.1.0",
-        "instrument_ontology": "5.1.0",
-        "length_unit_ontology": "5.1.0",
-        "mass_unit_ontology": "5.1.0",
-        "organ_ontology": "5.1.0",
-        "organ_part_ontology": "5.1.0",
-        "process_type_ontology": "5.1.0",
-        "protocol_type_ontology": "5.1.0",
-        "species_ontology": "5.1.0",
-        "strain_ontology": "5.1.0",
-        "time_unit_ontology": "5.1.0"
-      },
-      "process": {
-        "purchased_reagents": "5.1.0",
-        "sequencing": {
-          "barcode": "5.1.0",
-          "smartseq2": "5.1.0"
-        }
-
-      },
-      "project":{
-        "contact": "5.1.0",
-        "publication": "5.1.0"
-      }
-    },
-    "bundle": {
-      "biomaterial": "5.1.0",
-      "file": "1.0.0",
-      "ingest_audit": "5.1.0",
-      "links": "1.0.0",
-      "process": "5.2.1",
-      "project": "5.1.0",
-      "protocol": "5.1.0",
-      "reference": "1.0.1",
-      "submission": "5.1.0"
     }
-  }
 }


### PR DESCRIPTION
This change has already been released in master as it was an urgent bug fix but I'm also including it here to avoid future issues when we do the big set of protoco/process changes.

### Release notes 

### [module/ontology/species_ontology.json - v5.1.1] - 2018-05-18
### Changed
Bug fix to make ontology validation work - root species ontology node changed from "NCBITaxon:131567" to ["OBI:0100026","NCBITaxon:2759"] to reflect usage in HCAO. Patch update to referencing biomaterials and bundles.


