### PR TITLE
Change target_cell_type to selected_cell_type. Fixes #233.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/biomaterial/cell_suspension.json - v6.0.0] - 2018-05-21
+### Changed
+Changed the field `target_cell_type` to `selected_cell_type`.
+
 ### [module/process/purchased_reagents.json - v5.2.0] - 2018-05-18
 ### Added
 Added a new field - `kit_titer` - to record the appropriate titer and volume recommendations found in a kit's Certificate of Analysis.

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -55,11 +55,12 @@
             "user_friendly": "Genus species"
         },
         "selected_cell_type": {
-            "description" : "The cell type(s) selected for to be present in the suspension. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/clo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000003.",
+            "description" : "The cell type(s) selected to be present in the suspension. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/clo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000003.",
             "type": "array",
             "items": {
 		        "$ref": "module/ontology/cell_type_ontology.json"
 	        },
+            "example": "fetal cardiomyocyte",
             "user_friendly": "Selected cell type"
        },
         "total_estimated_cells": {

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -54,13 +54,13 @@
             },
             "user_friendly": "Genus species"
         },
-        "target_cell_type": {
-            "description" : "Cell types expected to be present in the suspension. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/clo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000003.",
+        "selected_cell_type": {
+            "description" : "The cell type(s) selected for to be present in the suspension. Should be a child term of https://www.ebi.ac.uk/ols/ontologies/clo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCL_0000003.",
             "type": "array",
             "items": {
 		        "$ref": "module/ontology/cell_type_ontology.json"
 	        },
-            "user_friendly": "Target cell type"
+            "user_friendly": "Selected cell type"
        },
         "total_estimated_cells": {
             "description": "Total estimated number of cells in biomaterial. May be 1 for well-based assays.",

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -68,6 +68,7 @@
             "type": "integer",
             "maximum": 1000000000,
             "minimum": 0,
+            "example": "2100",
             "user_friendly": "Total estimated cell count"
         }
      }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -74,7 +74,7 @@
         "type": {
             "biomaterial": {
                 "cell_line": "5.1.1",
-                "cell_suspension": "5.1.1",
+                "cell_suspension": "6.0.0",
                 "donor_organism": "5.1.1",
                 "organoid": "5.1.1",
                 "specimen_from_organism": "5.1.1"


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->

This PR (Fixes #233) updates the `cell_suspension.json` schema to :
- change `target_cell_type` to `selected_cell_type`
- add missing examples

This is a major change because it changes a field name (essentially removing a field and adding a new field).

### Release notes

### [type/biomaterial/cell_suspension.json - v6.0.0] - 2018-05-21
### Changed
Changed the field `target_cell_type` to `selected_cell_type`.
