### PR TITLE
Bug fix - ontology module updates

### DIFF
--- a/json_schema/module/ontology/biological_macromolecule_ontology.json
+++ b/json_schema/module/ontology/biological_macromolecule_ontology.json
@@ -27,7 +27,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:chebi", "obo:efo", "obo:obi"],
+                "ontologies" : ["obo:efo", "obo:chebi", "obo:obi"],
                 "classes": ["EFO:0004446"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/cell_cycle_ontology.json
+++ b/json_schema/module/ontology/cell_cycle_ontology.json
@@ -25,8 +25,8 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:go", "obo:efo"],
-                "classes": ["GO:0007049"],
+                "ontologies" : ["obo:hcao", "obo:go"],
+                "classes": ["GO:0007049", "GO:0022403"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/cell_type_ontology.json
+++ b/json_schema/module/ontology/cell_type_ontology.json
@@ -25,7 +25,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:cl", "obo:efo"],
+                "ontologies" : ["obo:hcao", "obo:cl"],
                 "classes": ["CL:0000003"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/development_stage_ontology.json
+++ b/json_schema/module/ontology/development_stage_ontology.json
@@ -25,8 +25,8 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:efo"],
-                "classes": ["EFO:0000399"],
+                "ontologies" : ["obo:efo", "obo:hcao"],
+                "classes": ["EFO:0000399", "HsapDv:0000000", "UBERON:0000105"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/disease_ontology.json
+++ b/json_schema/module/ontology/disease_ontology.json
@@ -25,8 +25,8 @@
             "description": "An optional ontology reference in format where prefix_ indicates which ontology",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:efo"],
-                "classes": ["MONDO:0000001", "EFO:0000408", "PATO:0000461"],
+                "ontologies" : ["obo:mondo", "obo:efo"],
+                "classes": ["MONDO:0000001", "PATO:0000461"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/length_unit_ontology.json
+++ b/json_schema/module/ontology/length_unit_ontology.json
@@ -27,7 +27,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:uo, obo:efo"],
+                "ontologies" : ["obo:efo", "obo:uo"],
                 "classes": ["UO:0000001"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/mass_unit_ontology.json
+++ b/json_schema/module/ontology/mass_unit_ontology.json
@@ -27,7 +27,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:uo, obo:efo"],
+                "ontologies" : ["obo:efo", "obo:uo"],
                 "classes": ["UO:0000002"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/organ_ontology.json
+++ b/json_schema/module/ontology/organ_ontology.json
@@ -26,7 +26,7 @@
             "description": "A term from the ontology [UBERON](https://www.ebi.ac.uk/ols/ontologies/uberon) for an organ or a cellular bodily fluid such as blood or lymph.",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:uberon", "obo:efo"],
+                "ontologies" : ["obo:hcao", "obo:uberon"],
                 "classes": ["UBERON:0000062","UBERON:0000179"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/organ_part_ontology.json
+++ b/json_schema/module/ontology/organ_part_ontology.json
@@ -26,7 +26,7 @@
             "description": "A term for a specific part of an organ from the ontology [UBERON](https://www.ebi.ac.uk/ols/ontologies/uberon).",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:uberon", "obo:efo"],
+                "ontologies" : ["obo:hcao", "obo:uberon"],
                 "classes": ["UBERON:0000465"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/protocol_type_ontology.json
+++ b/json_schema/module/ontology/protocol_type_ontology.json
@@ -26,7 +26,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:obi", "obo:efo"],
+                "ontologies" : ["obo:efo", "obo:obi"],
                 "classes": ["OBI:0000272"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/species_ontology.json
+++ b/json_schema/module/ontology/species_ontology.json
@@ -26,7 +26,7 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:NCBITaxon", "obo:efo"],
+                "ontologies" : ["obo:efo", "obo:NCBITaxon"],
                 "classes": ["OBI:0100026", "NCBITaxon:2759"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/strain_ontology.json
+++ b/json_schema/module/ontology/strain_ontology.json
@@ -26,8 +26,8 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:NCBITaxon", "obo:efo"],
-                "classes": ["NCBITaxon:131567", "EFO:0004472"],
+                "ontologies" : ["obo:efo", "obo:NCBITaxon"],
+                "classes": ["NCBITaxon:10090"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/time_unit_ontology.json
+++ b/json_schema/module/ontology/time_unit_ontology.json
@@ -26,8 +26,8 @@
             "description": "An ontology term identifier in the form prefix:accession",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:uo, obo:efo"],
-                "classes": ["UO:0000003, UO:0000149"],
+                "ontologies" : ["obo:efo", "obo:uo"],
+                "classes": ["UO:0000003", "UO:0000149"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,15 +1,15 @@
 {
-    "last_update_date": "2018-05-18T12:40:31Z",
+    "last_update_date": "2018-05-21T17:11:31Z",
     "version_numbers": {
         "bundle": {
-            "biomaterial": "5.1.1",
+            "biomaterial": "5.1.2",
             "file": "1.0.0",
             "ingest_audit": "5.1.0",
             "links": "1.0.0",
-            "process": "5.2.1",
+            "process": "5.2.2",
             "project": "5.1.0",
-            "protocol": "5.1.0",
-            "reference": "1.0.2",
+            "protocol": "5.1.1",
+            "reference": "1.0.3",
             "submission": "5.1.0"
         },
         "core": {
@@ -31,33 +31,33 @@
         },
         "module": {
             "biomaterial": {
-                "cell_morphology": "5.1.0",
+                "cell_morphology": "5.1.1",
                 "death": "5.1.0",
                 "familial_relationship": "5.1.0",
                 "growth_conditions": "6.0.0",
                 "homo_sapiens_specific": "5.1.0",
                 "medical_history": "5.1.0",
-                "mus_musculus_specific": "5.1.0",
-                "preservation_storage": "5.1.0",
+                "mus_musculus_specific": "5.1.1",
+                "preservation_storage": "5.1.1",
                 "state_of_specimen": "5.1.0"
             },
             "ontology": {
-                "biological_macromolecule_ontology": "5.1.0",
-                "cell_cycle_ontology": "5.1.0",
-                "cell_type_ontology": "5.1.0",
-                "development_stage_ontology": "5.1.0",
-                "disease_ontology": "5.1.0",
+                "biological_macromolecule_ontology": "5.1.1",
+                "cell_cycle_ontology": "5.1.1",
+                "cell_type_ontology": "5.1.1",
+                "development_stage_ontology": "5.1.1",
+                "disease_ontology": "5.1.1",
                 "ethnicity_ontology": "5.1.0",
                 "instrument_ontology": "5.1.0",
-                "length_unit_ontology": "5.1.0",
-                "mass_unit_ontology": "5.1.0",
-                "organ_ontology": "5.1.0",
-                "organ_part_ontology": "5.1.0",
+                "length_unit_ontology": "5.1.1",
+                "mass_unit_ontology": "5.1.1",
+                "organ_ontology": "5.1.1",
+                "organ_part_ontology": "5.1.1",
                 "process_type_ontology": "5.1.0",
-                "protocol_type_ontology": "5.1.0",
-                "species_ontology": "5.1.1",
-                "strain_ontology": "5.1.0",
-                "time_unit_ontology": "5.1.0"
+                "protocol_type_ontology": "5.1.1",
+                "species_ontology": "5.1.2",
+                "strain_ontology": "5.1.1",
+                "time_unit_ontology": "5.1.1"
             },
             "process": {
                 "purchased_reagents": "5.2.0",
@@ -73,15 +73,15 @@
         },
         "type": {
             "biomaterial": {
-                "cell_line": "5.1.1",
-                "cell_suspension": "6.0.0",
-                "donor_organism": "5.1.1",
-                "organoid": "5.1.1",
-                "specimen_from_organism": "5.1.1"
+                "cell_line": "5.1.2",
+                "cell_suspension": "6.0.1",
+                "donor_organism": "5.1.2",
+                "organoid": "5.1.2",
+                "specimen_from_organism": "5.1.2"
             },
             "file": {
                 "analysis_file": "5.1.0",
-                "reference_file": "1.0.2",
+                "reference_file": "1.0.3",
                 "sequence_file": "5.1.0"
             },
             "process": {
@@ -98,7 +98,7 @@
                 },
                 "process": "1.0.0",
                 "sequencing": {
-                    "library_preparation_process": "5.1.0",
+                    "library_preparation_process": "5.1.1",
                     "sequencing_process": "5.1.0"
                 }
             },
@@ -107,17 +107,17 @@
             },
             "protocol": {
                 "analysis": {
-                    "analysis_protocol": "5.1.0"
+                    "analysis_protocol": "5.1.1"
                 },
                 "biomaterial": {
-                    "biomaterial_collection_protocol": "5.1.0"
+                    "biomaterial_collection_protocol": "5.1.1"
                 },
                 "imaging": {
-                    "imaging_protocol": "5.1.0"
+                    "imaging_protocol": "5.1.1"
                 },
-                "protocol": "5.1.0",
+                "protocol": "5.1.1",
                 "sequencing": {
-                    "sequencing_protocol": "5.1.0"
+                    "sequencing_protocol": "5.1.1"
                 }
             }
         }


### PR DESCRIPTION
We recently switched from using the public Ontology Lookup Service (OLS) to our own internal OLS version, which only uses HCA-relevant ontologies. This has temporarily broken ontology validation as several of the ontologies used as a whole before are now slimmed into either HCAO or HCA-specific EFO. I have updated the relevant ontology modules to use the correct ontologies and/or root classes. This update is a bug fix and therefore a patch increment.
