### PR TITLE
removing has_input_biomaterial from biomaterial_core.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [core/biomaterial/biomaterial_core.json - v6.0.0] - 2018-05-23
+### Removed
+Removed the `has_input_biomaterial` property as the purpose is missleading and no longer required by the spreadsheet importer
+
 ### [type/biomaterial/cell_suspension.json - v6.0.0] - 2018-05-21
 ### Changed
 Changed the field `target_cell_type` to `selected_cell_type`.

--- a/json_schema/core/biomaterial/biomaterial_core.json
+++ b/json_schema/core/biomaterial/biomaterial_core.json
@@ -43,12 +43,6 @@
             },
             "user_friendly": "NCBI taxon ID"
         },
-        "has_input_biomaterial": {
-            "description": "If this biomaterial is derived from another biomaterial, enter the biomaterial_id for the biomaterial it was derived from.",
-            "type": "string",
-            "comment": "This field is primarily required for spreadsheet-based submissions.",
-            "user_friendly": "Input biomaterial ID"
-        },
         "genotype": {
             "description": "Genotype of biomaterial including strain, cross, and genetic modification information.",
             "type": "string",

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -14,7 +14,7 @@
         },
         "core": {
             "biomaterial": {
-                "biomaterial_core": "5.1.0"
+                "biomaterial_core": "6.0.0"
             },
             "file": {
                 "file_core": "5.1.0"


### PR DESCRIPTION
`has_input_biomaterial` is a bit of a red herring in the JSON schema. It is basically these for the old spreadsheet importer to work out how to link an input biomaterial. In the new spreadsheet importer this is no longer required as you will have a dedicated column like "Derived from Donor id". This logic lives with the spreadsheet builder/importer, not in the JSON schema. 

The links between biomaterials are represented in ingest through the Ingest API and in bundles via the `links.json` file so `has_input_biomaterial` is redundant. 

This field is ignored by the spreadsheet importer, so having it in the schema is misleading. 

## Change log

### [core/biomaterial/biomaterial_core.json - v6.0.0] - 2018-05-23
### Removed
Removed the `has_input_biomaterial` property as the purpose is missleading and no longer required by the spreadsheet importer

