### PR TITLE
Made several fields in types required and updated changelog. Fixes #307

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,26 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/file/reference_file.json - v?+1.0.0] - 2018-06-04
+### Changed
+Made fields `ncbi_taxon_id`, `genus_species`, `assembly_type`, `reference_type` and `reference_version` required.
+
+### [type/protocol/imaging/imaging_protocol.json - v?+1.0.0] - 2018-06-04
+### Changed
+Made field `protocol_type` required.
+
+### [type/protocol/biomaterial_collection/dissociation_protocol.json - v?+1.0.0] - 2018-06-04
+### Changed
+Made field `nucleic_acid_source` required.
+
+### [type/protocol/analysis/analysis_protocol.json - v?+1.0.0] - 2018-06-04
+### Changed
+Made field `protocol_type` required.
+
+### [type/biomaterial/cell_line.json - v?+1.0.0] - 2018-06-04
+### Changed
+Made field `cell_line_type` required.
+
 ### [type/biomaterial/cell_line.json - v6.1.1] - 2018-06-04
 ### Changed
 Updated the description for the schema.

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -5,7 +5,8 @@
     "required": [
         "describedBy",
         "schema_type",
-        "biomaterial_core"
+        "biomaterial_core",
+        "cell_line_type"
     ],
     "title": "cell_line",
     "type": "object",

--- a/json_schema/type/file/reference_file.json
+++ b/json_schema/type/file/reference_file.json
@@ -5,7 +5,12 @@
     "required": [
         "describedBy",
         "schema_type",
-        "file_core"
+        "file_core",
+        "ncbi_taxon_id",
+        "genus_species",
+        "assembly_type",
+        "reference_type",
+        "reference_version"
     ],
     "title": "reference_file",
     "type": "object",

--- a/json_schema/type/protocol/analysis/analysis_protocol.json
+++ b/json_schema/type/protocol/analysis/analysis_protocol.json
@@ -14,7 +14,8 @@
         "analysis_run_type",
         "tasks",
         "inputs",
-        "outputs"
+        "outputs",
+        "protocol_type"
     ],
     "title": "analysis_protocol",
     "type": "object",

--- a/json_schema/type/protocol/biomaterial_collection/dissociation_protocol.json
+++ b/json_schema/type/protocol/biomaterial_collection/dissociation_protocol.json
@@ -6,7 +6,8 @@
         "describedBy",
         "schema_type",
         "protocol_core",
-        "dissociation_method"
+        "dissociation_method",
+        "nucleic_acid_source"
     ],
     "title": "dissociation_protocol",
     "type": "object",

--- a/json_schema/type/protocol/imaging/imaging_protocol.json
+++ b/json_schema/type/protocol/imaging/imaging_protocol.json
@@ -5,7 +5,8 @@
     "required": [
         "describedBy",
         "schema_type",
-        "protocol_core"
+        "protocol_core",
+        "protocol_type"
     ],
     "title": "imaging_protocol",
     "type": "object",


### PR DESCRIPTION
All fields identified in https://docs.google.com/spreadsheets/d/1dQHuiVftSTEqrY85lX1Tr73hDa64do0aBbnhB7_4aJ8/edit#gid=0 as needing to be required were converted to required fields, with the exception of several protocol_type fields, which were recently deprecated in favour of more detailed _method or _approach fields.

This is a major version change as it is not necessarily backwards compatible.

NB: Changelog updated without version numbers. Versions file needs updating.
