### PR TITLE
[WIP] Added field purchased_specimen to specimen type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/biomaterial/specimen_from_organism.json - v5.?+1.0] - 2018-06-07
+### Added
+Added the field `purchased_specimen` referencing the purchased_reagents module, to capture purchasing of specimens such as blood samples.
+
 ### [type/project/project.json - v?.+1.?] - 2018-06-06
 ### Changed
 Added a pointer to new module with three optional fields to track project funders.

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -82,6 +82,12 @@
             "type": "string",
             "format": "date-time",
             "user_friendly": "Time of collection"
+        },
+        "purchased_specimen": {
+            "description": "Information about a purchased specimen.",
+            "type": "object",
+            "$ref": "module/process/purchased_reagents.json",
+            "user_friendly": "Purchased specimen"
         }
     }
 }


### PR DESCRIPTION
Fixes #333

### [type/biomaterial/specimen_from_organism.json - v5.?+1.0] - 2018-06-07
### Added
Added the field `purchased_specimen` referencing the purchased_reagents module, to capture purchasing of specimens such as blood samples.

**NB**: Do Do not merge this PR into develop until **after Monday 11 June.**