### PR TITLE
Rename start_time to length_of_time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,15 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [core/process/process_core.json - v?+1.0.0] - 2018-06-07
+### Changed
+Renamed `start_time` to `length_of_time` with updated description and added a number-only patterns.
+
+### Added
+Added `length_of_time_unit` referencing the time unit ontology module to provide a time unit for the duration in the `length_of_time` field.
+
+
+
 ### [type/project/project.json - v?.+1.?] - 2018-06-06
 ### Changed
 Added a pointer to new module with three optional fields to track project funders.

--- a/json_schema/core/process/process_core.json
+++ b/json_schema/core/process/process_core.json
@@ -34,13 +34,19 @@
             "type": "string",
             "user_friendly": "Process description"
         },
-         "start_time": {
-            "description": "When the process started, in date-time format, yyyy-mm-ddThh:mm:ssZ.",
+         "length_of_time": {
+            "description": "Length of time the process took to execute, from start to finish, in an appropriate time unit.",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
             "type": "string",
-            "format": "date-time",
-            "example": "2018-01-31T08:30:00Z",
             "user_friendly": "Start time"
          },
+        "length_of_time_unit": {
+            "description": "The unit in which the length of time is expressed. Must be one of microsecond, second, minute, hour, day, week, month, or year.",
+            "type": "object",
+            "$ref": "module/ontology/time_unit_ontology.json",
+            "user_friendly": "Length of time unit",
+            "example": "second"
+        },
          "process_location": {
             "description": "Where the process took place.",
             "type": "string",


### PR DESCRIPTION
### [core/process/process_core.json - v?+1.0.0] - 2018-06-07
### Changed
Renamed `start_time` to `length_of_time` with updated description and added a number-only patterns.

### Added
Added `length_of_time_unit` referencing the time unit ontology module to provide a time unit for the duration in the `length_of_time` field.

**NB**: Do not release until **after Monday 11 June 2018.**
