### PR TITLE
Fix broken links in markdown files (issue #392)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,17 +12,17 @@ List of fields in the HCA metadata standard that can currently be annotated with
 
 ### contributing.md
 
-Information on [how to contribute](docs/contributing.md) to the HCA metadata standards.
+Information on [how to contribute](contributing.md) to the HCA metadata standards.
 
 ### evolution.md
 
-[Evolution and update principles](docs/evolution.md) for the HCA metadata standards.
+[Evolution and update principles](evolution.md) for the HCA metadata standards.
 
 ### rationale.md
 
-Rationale for the [design and implementation choices](docs/rationale.md) for the HCA metadata standards.
+Rationale for the [design and implementation choices](rationale.md) for the HCA metadata standards.
 
 ### structure.md
 
-Overview of the [structure](docs/structure.md) of the HCA metadata standards.
+Overview of the [structure](structure.md) of the HCA metadata standards.
 

--- a/docs/committers.md
+++ b/docs/committers.md
@@ -19,14 +19,14 @@ This document serves as an SOP for committers who are ultimately responsible for
  - HCA DCP internal developers
 
 **What *isn't* in this document?**
-- Description of what defines [major, minor, and patch changes](metadata-schema/docs/evolution.md#schema-versioning) to the metadata schema
-- Directions for [reporting bugs](metadata-schema/docs/contributing.md#reporting-bugs) in the metadata schema
+- Description of what defines [major, minor, and patch changes](evolution.md#schema-versioning) to the metadata schema
+- Directions for [reporting bugs](contributing.md#reporting-bugs) in the metadata schema
 
 ## Steps of the update process
 
 1. **Acquire feedback on the HCA metadata standard.** Anyone can suggest changes to the metadata standards via three main routes:
     1. Create a [GitHub issue](https://github.com/HumanCellAtlas/metadata-schema/issues/new) on the metadata-schema GitHub repo
-    1. Email the HCA DCP helpdesk at data-help@humancellaltas.org
+    1. Email the HCA DCP helpdesk at [data-help@humancellaltas.org](mailto:data-help@humancellaltas.org)
     1. Make a pull request against the develop branch of the metadata-schema GitHub repo
 
     There are two main types of suggestions: (1) **updates** to existing schemas and (2) addition of **new** schema(s).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,7 +58,7 @@ As a prerequisite to this section, you may want to look at [how the metadata is 
 1. **Submit request on the HCA metadata standard.** Anyone can suggest/request changes to the metadata standards via three main routes:
 
     1. Create a [GitHub issue](https://github.com/HumanCellAtlas/metadata-schema/issues/new) on the metadata-schema repo
-    1. Email the HCA DCP helpdesk at [data-help@humancellaltas.org](data-help@humancellaltas.org)
+    1. Email the HCA DCP helpdesk at [data-help@humancellaltas.org](mailto:data-help@humancellaltas.org)
     1. Make a pull request against the develop branch of the metadata-schema repo (only recommended for users with familiarity with GitHub)
     
     Whichever method is chosen, the information indicated in Step 1 is requested to be submitted.

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -22,7 +22,7 @@ This document describes the principles and standards by which the HCA metadata s
  - Internal HCA DCP developers, especially those who depend on schema versions
 
 **What *isn't* in this document?**
- - Mechanism by which [approved committers implement the update process](metadata-schema/docs/committers.md)
+ - Mechanism by which [approved committers implement the update process](committers.md)
 
 ## Schema versioning
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -18,7 +18,7 @@ This document describes reasons and rationale behind certain implementation and 
  - Members of external projects seeking alignment with HCA metadata standards
 
 **What *isn't* in this document?**
-- The [structure of metadata standards](metadata-schema/docs/structure.md) that resulted from following the design and implementation choices outlined here.
+- The [structure of metadata standards](structure.md) that resulted from following the design and implementation choices outlined here.
  
 ## Implementation choices
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -19,7 +19,7 @@ This document describes the structure of the HCA metadata standards. More detail
  - Members of external projects seeking alignment with HCA metadata standards
 
 **What *isn't* in this document?**
- - The set of [principles](metadata-schema/docs/rationale.md#design-choices) specifically guiding the schema structure design
+ - The set of [principles](rationale.md#design-choices) specifically guiding the schema structure design
  
 ## Structure overview
 


### PR DESCRIPTION

fixes #392

Mulitple *.md files in the markdown have broken links because they are relative to the top of the tree, not the current directory. There are also errors in mailto links. PR coming that shows and corrects this.


