### PR TITLE
is_living typo fix in donor_organism schema

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/biomaterial/donor_organism.json - v?.?.?+1] - 2018-07-04
+### Fixed
+Fixed typo in `is_living` enum from "unkown" to "unknown"
+
 ### [bundle/biomaterial.json - v10.2.0] - 2018-06-26
 ### Added
 Added optional field `ontology_label` to all ontology modules.

--- a/json_schema/type/biomaterial/donor_organism.json
+++ b/json_schema/type/biomaterial/donor_organism.json
@@ -129,7 +129,7 @@
             "enum": [
                 "yes",
                 "no",
-                "unkown"
+                "unknown"
             ],
             "user_friendly": "Is living?"
         }, 


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->

### [type/biomaterial/donor_organism.json - v?.?.?+1] - 2018-07-04
### Fixed
Fixed typo in `is_living` enum from "unkown" to "unknown"
