### PR TITLE
Supplementary file schema fixes #313

### DIFF
--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -48,7 +48,7 @@
             "user_friendly": "Supplementary type"
         },
         "data_source": {
-            "description": "A link to an external database record.",
+            "description": "A link to an external database record or analysis pipeline.",
             "type": "string",
             "example": "https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=GM17372&PgId=166",
             "user_friendly": "Data source"

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -7,7 +7,6 @@
         "schema_type",
         "file_core",
         "supplementary_type",
-        "source_method_name"
     ],
     "title": "supplementary_file",
     "type": "object",
@@ -47,10 +46,15 @@
             "user_friendly": "Supplementary type"
         },
         "source_method_name": {
-            "description": "The method or technique used to derive the supplementary file.",
+            "description": "The method, technique used to derive the supplementary file.",
             "type": "object",
             "$ref": "module/ontology/process_type_ontology.json",
             "user_friendly": "Source method name"
+        },
+        "data_source": {
+            "description": "A link to an external database record.",
+            "type": "string",
+            "user_friendly": "Data source"
         }
     }
 }

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -6,7 +6,8 @@
         "describedBy",
         "schema_type",
         "file_core",
-        "supplementary_type"
+        "supplementary_type",
+        "source_method_name"
     ],
     "title": "supplementary_file",
     "type": "object",
@@ -14,7 +15,7 @@
         "describedBy": {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/type/file/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/sequence_file"
+            "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/type/file/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/supplementary_file"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
@@ -45,17 +46,11 @@
             ],
             "user_friendly": "Supplementary type"
         },
-        "protocol_core" : {
-            "description": "Core protocol-level information.",
-            "type": "object",
-            "$ref": "core/protocol/protocol_core.json"
-        },
-        "source_method": {
-            "description": "The method or technique used to derrive the supplementary file.",
+        "source_method_name": {
+            "description": "The method or technique used to derive the supplementary file.",
             "type": "object",
             "$ref": "module/ontology/process_type_ontology.json",
-            "user_friendly": "Source method"
-        },
-
+            "user_friendly": "Source method name"
+        }
     }
 }

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -41,15 +41,9 @@
             "enum": [
                 "Supplementary analysis",
                 "Supplementary data",
-                "Supplementary metadata"
+                "Supplementary metadata",
             ],
             "user_friendly": "Supplementary type"
-        },
-        "source_method_name": {
-            "description": "The method, technique used to derive the supplementary file.",
-            "type": "object",
-            "$ref": "module/ontology/process_type_ontology.json",
-            "user_friendly": "Source method name"
         },
         "data_source": {
             "description": "A link to an external database record.",

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -42,6 +42,7 @@
                 "Supplementary analysis",
                 "Supplementary data",
                 "Supplementary metadata",
+                "Protocol"
             ],
             "user_friendly": "Supplementary type"
         },

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -42,7 +42,8 @@
                 "Supplementary analysis",
                 "Supplementary data",
                 "Supplementary metadata",
-                "Protocol"
+                "Protocol",
+                "Cell barcode whitelist file"
             ],
             "user_friendly": "Supplementary type"
         },

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -50,6 +50,7 @@
         "data_source": {
             "description": "A link to an external database record.",
             "type": "string",
+            "example": "https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=GM17372&PgId=166",
             "user_friendly": "Data source"
         }
     }

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -35,7 +35,7 @@
             "$ref": "core/file/file_core.json"
         },
         "supplementary_type": {
-            "description": "One of either 'Supplementary analysis', 'Supplementary data', 'Supplementary metadata' ",
+            "description": "The type of supplementary information that can be found in the file.",
             "type": "string",
             "example": "Supplementary analysis",
             "enum": [

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -6,7 +6,7 @@
         "describedBy",
         "schema_type",
         "file_core",
-        "supplementary_type",
+        "supplementary_type"
     ],
     "title": "supplementary_file",
     "type": "object",

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Supplementary files belonging to a project.",
+    "additionalProperties": false,
+    "required": [
+        "describedBy",
+        "schema_type",
+        "file_core",
+        "supplementary_type"
+    ],
+    "title": "supplementary_file",
+    "type": "object",
+    "properties": {
+        "describedBy": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/type/file/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/sequence_file"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "file"
+            ]
+        },
+        "file_core" : {
+            "description": "Core file-level information.",
+            "type": "object",
+            "$ref": "core/file/file_core.json"
+        },
+        "supplementary_type": {
+            "description": "One of either 'Supplementary analysis', 'Supplementary data', 'Supplementary metadata' ",
+            "type": "string",
+            "example": "Supplementary analysis",
+            "enum": [
+                "Supplementary analysis",
+                "Supplementary data",
+                "Supplementary metadata"
+            ],
+            "user_friendly": "Supplementary type"
+        },
+        "protocol_core" : {
+            "description": "Core protocol-level information.",
+            "type": "object",
+            "$ref": "core/protocol/protocol_core.json"
+        },
+        "source_method": {
+            "description": "The method or technique used to derrive the supplementary file.",
+            "type": "object",
+            "$ref": "module/ontology/process_type_ontology.json",
+            "user_friendly": "Source method"
+        },
+
+    }
+}

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -5,7 +5,7 @@
     "required": [
         "describedBy",
         "schema_type",
-        "file_core",
+        "file_core"
     ],
     "title": "supplementary_file",
     "type": "object",
@@ -32,6 +32,6 @@
             "description": "Core file-level information.",
             "type": "object",
             "$ref": "core/file/file_core.json"
-        },
+        }
     }
 }

--- a/json_schema/type/file/supplementary_file.json
+++ b/json_schema/type/file/supplementary_file.json
@@ -6,7 +6,6 @@
         "describedBy",
         "schema_type",
         "file_core",
-        "supplementary_type"
     ],
     "title": "supplementary_file",
     "type": "object",
@@ -34,24 +33,5 @@
             "type": "object",
             "$ref": "core/file/file_core.json"
         },
-        "supplementary_type": {
-            "description": "The type of supplementary information that can be found in the file.",
-            "type": "string",
-            "example": "Supplementary analysis",
-            "enum": [
-                "Supplementary analysis",
-                "Supplementary data",
-                "Supplementary metadata",
-                "Protocol",
-                "Cell barcode whitelist file"
-            ],
-            "user_friendly": "Supplementary type"
-        },
-        "data_source": {
-            "description": "A link to an external database record or analysis pipeline.",
-            "type": "string",
-            "example": "https://www.coriell.org/0/Sections/Search/Sample_Detail.aspx?Ref=GM17372&PgId=166",
-            "user_friendly": "Data source"
-        }
     }
 }


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->

### Release notes:

This PR adds the type supplementary_file.json. This is a first suggestion. Discussion around this issue highlights the requirement for very flexible schema that encourages submitters to add supplementary files.

file_core satisfies most requirements. In addition to this I propose three new fields 'supplementary_type' (required), 'source_method_name' and 'data_source'.

**supplementary_type** is a enum for one of "Supplementary analysis", "Supplementary data" and "Supplementary metadata". This broad categorisation along with the link to the biomaterial helps users to understand what the file contains. The data viewer could group files based on this field.

**source_method_name** this field is ontology linked and should contain the method or technique that was used to derive the supplementary data/analysis. this will allow us to investigate types supplementary information across multiple datasets to scope further ingest use cases.

**data_source** this is an optional field to link to a database record. For example this is useful to link to health records or data records.

These three fields could be removed if they are too restrictive. I held off adding links to method pdf document because a supplementary file about a supplementary file felt too complex. I also didn't provide a way to easily reference analysis pipelines that may have been used to generate the supplementary information.