### PR TITLE
Ran release_prepare.py script. Fixes #596 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [module/protocol/imaging_target.json - v2.0.0] - 2018-11-21
+### Changed
+Changed channel field type to array
+
+### [type/protocol/imaging/imaging_protocol.json - v9.0.0] - 2018-11-21
+### Changed
+Changed channel field type to array
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/protocol/imaging_target.json - v1.1.0] - 2018-11-19

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-module/protocol/imaging_target,major,Changed channel field type to array,,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2018-11-19T11:20:02Z",
+    "last_update_date": "2018-11-21T17:47:02Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -71,7 +71,7 @@
             },
             "protocol": {
                 "channel": "1.0.1",
-                "imaging_target": "1.1.0"
+                "imaging_target": "2.0.0"
             }
         },
         "system": {
@@ -117,7 +117,7 @@
                 },
                 "imaging": {
                     "imaging_preparation_protocol": "1.0.1",
-                    "imaging_protocol": "8.1.0"
+                    "imaging_protocol": "9.0.0"
                 },
                 "protocol": "6.3.5",
                 "sequencing": {


### PR DESCRIPTION
The original PR made by Zina was prematurely merged (by me). I reversed this (via another PR) and merged back to develop to undo the changes. Despite confirming the differenced between dev and Zina's branch the PR in github was detecting no changes. We were unable to work out why when there clearly were changes. This PR addresses that. Here I took Zina's branch ran the release script properly and now will merge this straight to develop. End result should be the same but the process took 3 PRs rather than one. To remedy this situation Zina has some recommendations to change the instructions a little to make them clearer.
