### PR TITLE
Added two option fields for ENA submission Fixes #594

### DIFF
--- a/json_schema/type/protocol/sequencing/library_preparation_protocol.json
+++ b/json_schema/type/protocol/sequencing/library_preparation_protocol.json
@@ -156,6 +156,18 @@
             "$ref": "module/ontology/library_amplification_ontology.json",
             "user_friendly": "cDNA library amplification method",
             "example": "PCR"
+        },
+        "nominal_length": {
+            "description": "Average (insert) size of the fragments being sequenced.",
+            "type": "integer",
+            "user_friendly": "Nominal length",
+            "example": "250"
+        },
+        "nominal_sdev": {
+            "description": "Standard deviation of the (insert) size of the fragments being sequenced.",
+            "type": "integer",
+            "user_friendly": "Nominal standard deviation",
+            "example": "30"
         }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,3 @@
 Schema,Change type,Change message,Version,Date
+type/protocol/sequencing/library_preparation_protocol,minor,"Added new optional field nominal_length",,
+type/protocol/sequencing/library_preparation_protocol,minor,"Added new optional field nominal_sdev",,


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->
Ran schemas_are_valid_json.py and json_examples_validate_against_schema.py
<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->
Minor schema edit. Two new fields added to type/protocol/sequencing/library_preparation_protocol

Added new optional field nominal_length and nominal_sdev
```
"nominal_length": {
    "description": "Average (insert) size of the fragments being sequenced.",
    "type": "integer",
    "user_friendly": "Nominal length",
    "example": "250"
},
"nominal_sdev": {
    "description": "Standard deviation of the (insert) size of the fragments being sequenced.",
    "type": "integer",
    "user_friendly": "Nominal standard deviation",
    "example": "30"
```
