### PR TITLE
Sequence file patch updates.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/file/sequence_file.json - v7.0.1] - 2018-12-13
+### Changed
+Changed description, user-friendly, example, and guidelines attributes to adhere to Style Guide. Fixes #672.
+
 ### [system/license.json - v1.0.0] - 2018-12-07
 ### Added
 Added system entity to capture license under which data are released. Fixes #338.

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -87,7 +87,7 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | file | 
 file_core | Core file-level information. | object | [See core  file_core](core.md/#file_core) |  |  | 
-read_index | Whether the read file contains the read1, read2, index1, or index2 part of the sequencing read or represents a single-end, non-indexed library. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
+read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
 ### Supplementary file
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -86,7 +86,7 @@ reference_version | The genome version of the reference. | string |  | Reference
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | file | 
-file_core | Core file-level information. | object | [See core  file_core](core.md/#file_core) |  |  | 
+file_core | Core file-level information. | object | [See core  file_core](core.md/#file_core) | File core |  | 
 read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
 ### Supplementary file
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -87,7 +87,7 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | file | 
 file_core | Core file-level information. | object | [See core  file_core](core.md/#file_core) | File core |  | 
-read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
+read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
 ### Supplementary file
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -190,7 +190,7 @@ file_core | Core file-level information. | object | yes | [See core  file_core](
 read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
 lane_index | The index of the lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51
-insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Can be from the DDBJ, NCBI, or EMBL-EBI. Accession must start with DRR, SRR, or ERR. | array | no |  | INSDC run |  | SRR0000000
+insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession from the DDBJ, NCBI, or EMBL-EBI. | array | no |  | INSDC run |  | SRR0000000
 library_prep_id | A unique ID for the library preparation. | string | no |  | Library preparation ID |  | tech_rep_group_001
 
 ## Supplementary file

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -188,9 +188,9 @@ schema_type | The type of the metadata schema entity. | string | yes |  |  | fil
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) | File core |  | 
 read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
-lane_index | The index of the lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
+lane_index | The lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51
-insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession from the DDBJ, NCBI, or EMBL-EBI. | array | no |  | INSDC run |  | SRR0000000
+insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession from the DDBJ, NCBI, or EMBL-EBI. | array | no |  | INSDC run accession |  | SRR0000000
 library_prep_id | A unique ID for the library preparation. | string | no |  | Library preparation ID |  | tech_rep_group_001
 
 ## Supplementary file

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -187,7 +187,7 @@ Property name | Description | Type | Required? | Object reference? | User friend
 schema_type | The type of the metadata schema entity. | string | yes |  |  | file | 
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) |  |  | 
-read_index | Whether the read file contains the read1, read2, index1, or index2 part of the sequencing read or represents a single-end, non-indexed library. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
+read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
 lane_index | The index of the lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51
 insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Can be from the DDBJ, NCBI, or EMBL-EBI. Accession must start with DRR, SRR, or ERR. | array | no |  | INSDC run |  | SRR0000000

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -187,7 +187,7 @@ Property name | Description | Type | Required? | Object reference? | User friend
 schema_type | The type of the metadata schema entity. | string | yes |  |  | file | 
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) | File core |  | 
-read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
+read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
 lane_index | The lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51
 insdc_run | An INSDC (International Nucleotide Sequence Database Collaboration) run accession from the DDBJ, NCBI, or EMBL-EBI. | array | no |  | INSDC run accession |  | SRR0000000

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -186,7 +186,7 @@ Property name | Description | Type | Required? | Object reference? | User friend
 --- | --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string | yes |  |  | file | 
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
-file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) |  |  | 
+file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) | File core |  | 
 read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'
 lane_index | The index of the lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -67,14 +67,15 @@
             "user_friendly": "Read length"
         },
         "insdc_run": {
-            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) run accession. Can be from the DDBJ, NCBI, or EMBL-EBI. Accession must start with DRR, SRR, or ERR.",
+            "description": "An INSDC (International Nucleotide Sequence Database Collaboration) run accession from the DDBJ, NCBI, or EMBL-EBI.",
             "type": "array",
             "items": {
                 "pattern": "^[D|E|S]RR[0-9]+$",
                 "type": "string"
             },
             "user_friendly": "INSDC run",
-            "example": "SRR0000000"
+            "example": "SRR0000000",
+            "guidelines": "Accession must start with DRR, SRR, or ERR."
         },
         "library_prep_id" : {
             "description": "A unique ID for the library preparation.",

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -56,7 +56,7 @@
             "guidelines": "If a sequencing experiment is single-end, enter 'read1'."
         },
         "lane_index": {
-            "description": "The index of the lane that this file was sequenced from.",
+            "description": "The lane that this file was sequenced from.",
             "type": "integer",
             "example": 1,
             "user_friendly": "Lane index"
@@ -74,7 +74,7 @@
                 "pattern": "^[D|E|S]RR[0-9]+$",
                 "type": "string"
             },
-            "user_friendly": "INSDC run",
+            "user_friendly": "INSDC run accession",
             "example": "SRR0000000",
             "guidelines": "Accession must start with DRR, SRR, or ERR."
         },

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -41,7 +41,7 @@
             "$ref": "core/file/file_core.json"
         },
         "read_index": {
-            "description": "Whether the read file contains the read1, read2, index1, or index2 part of the sequencing read or represents a single-end, non-indexed library.",
+            "description": "The sequencing read this file represents.",
             "type": "string",
             "example": "Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'",
             "enum": [
@@ -51,7 +51,8 @@
                 "index2",
                 "single-end, non-indexed"
             ],
-            "user_friendly": "Read index"
+            "user_friendly": "Read index",
+            "guidelines": "If a sequencing experiment is single-end, enter 'read1'."
         },
         "lane_index": {
             "description": "The index of the lane that this file was sequenced from.",

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -44,7 +44,7 @@
         "read_index": {
             "description": "The sequencing read this file represents.",
             "type": "string",
-            "example": "Should be one of: read1, read2, index1, index2, or 'single-end, non-indexed'",
+            "example": "Should be one of: read1, read2, index1, index2",
             "enum": [
                 "read1",
                 "read2",

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -38,7 +38,8 @@
         "file_core" : {
             "description": "Core file-level information.",
             "type": "object",
-            "$ref": "core/file/file_core.json"
+            "$ref": "core/file/file_core.json",
+            "user_friendly": "File core"
         },
         "read_index": {
             "description": "The sequencing read this file represents.",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/file/sequence_file,patch,"Changed description, user-friendly, example, and guidelines attributes to adhere to Style Guide. Fixes #672.",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/file/sequence_file,patch,"Changed description, user-friendly, example, and guidelines attributes to adhere to Style Guide. Fixes #672.",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2018-12-07T21:56:55Z",
+    "last_update_date": "2018-12-13T14:28:19Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -92,7 +92,7 @@
                 "analysis_file": "5.3.4",
                 "image_file": "1.0.1",
                 "reference_file": "2.2.5",
-                "sequence_file": "7.0.0",
+                "sequence_file": "7.0.1",
                 "supplementary_file": "1.1.5"
             },
             "process": {


### PR DESCRIPTION
<!-- Please provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- If this PR updates the metadata schema, add a note describing the feature which will be added to the changelog. 
Indicate whether the update is to something Added, Changed, Removed, Fixed, Deprecated, or Securit. 
Uncomment the heading below:
### Release notes -->
### Release notes
- add user-friendly name to file_core
- remove "index of the" from lane_index description
- change description of read_index to "The sequencing read this file represents."
- add guidelines to read_index field to indicate that if a sequencing experiment is single-end, enter "read1".
- remove "Can be from the DDBJ, NCBI, or EMBL-EBI. Accession must start with DRR, SRR, or ERR." from description for insdc_run
- add guidelines to insdc_run: "Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with DRR, SRR, or ERR.".