### PR TITLE
Added a printed warning for update types

### DIFF
--- a/src/release_prepare.py
+++ b/src/release_prepare.py
@@ -81,6 +81,9 @@ class ReleasePrepare:
                 version = log_content[val][self.version_column]
                 type = change_message.split(' ')[0]
 
+                if type not in ['Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security']:
+                    print("WARNING: Change type in log message does not match one of 'Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security'")
+
                 markdown_message = "### [" + schema + ".json - v" + version + "] - " + update_date + "\n" + "### " + type  + "\n" + change_message  + "\n"
                 log_insert = log_insert + markdown_message  + "\n"
 

--- a/src/release_prepare.py
+++ b/src/release_prepare.py
@@ -81,9 +81,6 @@ class ReleasePrepare:
                 version = log_content[val][self.version_column]
                 type = change_message.split(' ')[0]
 
-                if type not in ['Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security']:
-                    print("WARNING: Change type in log message does not match one of 'Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security'")
-
                 markdown_message = "### [" + schema + ".json - v" + version + "] - " + update_date + "\n" + "### " + type  + "\n" + change_message  + "\n"
                 log_insert = log_insert + markdown_message  + "\n"
 
@@ -127,6 +124,14 @@ class ReleasePrepare:
             writer.writerow(h)
         writeChangeLog.close()
 
+    def checkUpdateLog(self, update_log):
+        for val in range(1, len(update_log)):
+            change_message = update_log[val][self.message_column]
+            type = change_message.split(' ')[0]
+            if type not in ['Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security']:
+                print(
+                    "WARNING: Change type in log message does not match one of 'Added', 'Changed', 'Removed', 'Fixed', 'Deprecated', 'Security'")
+                exit(2)
 
 class options:
     def __init__(self, p, s, i, e):
@@ -141,6 +146,8 @@ if __name__ == '__main__':
     releasePrep = ReleasePrepare()
 
     content_log = releasePrep.openUpdateLog()
+
+    releasePrep.checkUpdateLog(content_log)
 
     updated_versions = releasePrep.updateVersions(content_log)
 


### PR DESCRIPTION
As per recent discussion about the use of change vs changed etc, I've added a warning to the release script if the type isn't part of a defined list. The script will still pass but you should see a warning