### PR TITLE
Added new optional properties for file integrity check. Fixes #1289.

### DIFF
--- a/docs/jsonBrowser/core.md
+++ b/docs/jsonBrowser/core.md
@@ -18,6 +18,12 @@ file_name | The name of the file. | string | yes |  | File name |  | R1.fastq.gz
 format | The format of the file. | string | yes |  | File format |  | fastq.gz; tif
 content_description | General description of the contents of the file. | array | no | [See module  file_content_ontology](module.md/#file_content_ontology) | Content description |  | 
 checksum | MD5 checksum of the file. | string | no |  | Checksum |  | e09a986c2e630130b1849d4bf9a94c06
+content_type | An appropriate MIME type for this file. | string | no |  | Content type |  | application/gzip
+size | The size of the file in bytes. | number | no |  | Size |  | 2147483648
+sha256 | The sha256 hash of the file. | string | no |  | Sha256 |  | 12998c017066eb0d2a70b94e6ed3192985855ce390f321bbdb832022888bd251
+crc32c | The CRC-32C code generated for this file. | string | no |  | Crc32c |  | 3FBA199E
+sha1 | The sha1 hash of the file. | string | no |  | Sha1 |  | 6e71b3cac15d32fe2d36c270887df9479c25c640
+s3_etag | The AWS S3 ETag for this file | string | no |  | s3 ETag |  | 
 
 ## Protocol core<a name='Protocol core'></a>
 _Information about an intended protocol that was followed in the project._

--- a/json_schema/core/file/file_core.json
+++ b/json_schema/core/file/file_core.json
@@ -48,7 +48,47 @@
             "description": "MD5 checksum of the file.",
             "type": "string",
             "user_friendly": "Checksum",
-            "example": "e09a986c2e630130b1849d4bf9a94c06"
-	    }
+            "example": "e09a986c2e630130b1849d4bf9a94c06",
+            "pattern": "^[a-f0-9]{32}$"
+	    },
+        "content_type": {
+            "description": "An appropriate MIME type for this file.",
+            "type": "string",
+            "user_friendly": "Content type",
+            "example": "application/gzip"
+        },
+        "size": {
+            "description": "The size of the file in bytes.",
+            "type": "number",
+            "minimum": 0,
+            "user_friendly": "Size",
+            "example": 2147483648
+        },
+        "sha256": {
+            "description": "The sha256 hash of the file.",
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{64}",
+            "user_friendly": "Sha256",
+            "example": "12998c017066eb0d2a70b94e6ed3192985855ce390f321bbdb832022888bd251"
+        },
+        "crc32c": {
+            "description": "The CRC-32C code generated for this file.",
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{8}",
+            "user_friendly": "Crc32c",
+            "example": "3FBA199E"
+        },
+        "sha1": {
+            "description": "The sha1 hash of the file.",
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{40}",
+            "user_friendly": "Sha1",
+            "example": "6e71b3cac15d32fe2d36c270887df9479c25c640"
+        },
+        "s3_etag" : {
+            "description": "The AWS S3 ETag for this file",
+            "user_friendly": "s3 ETag",
+            "type": "string"
+        }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,2 @@
 Schema,Change type,Change message,Version,Date
-
+core/file/file_core,minor,"Added new optional properties for file integrity check. Fixes #1289.",,


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

For core/file/file_core.json schema:
- Added `content_type` property
- Added `size` property
- Added `sha256` property
- Added `crc32c` property
- Added `sha1` property
- Added `s3_etag` property
 

### Reviews requested

- Need 2 Reviewers (But 3 will review due to circumstances) to approve because this is a minor update
- This hotfix will be merged by me once the PR has been reviewed.
