### PR TITLE
Fix failing travis tests

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -70,6 +70,7 @@ groups:
       - willrockout
       - pnejad
       - ESapenaVentura
+      - rachadele
     reviews:  # settings for approval and reviewer selection
       required: 2
       request_order: shuffle  # reviewers will be chosen in a random order
@@ -94,6 +95,7 @@ groups:
         - willrockout
         - pnejad
         - ESapenaVentura
+        - rachadele
     reviews:
       required: 1
       request_order: shuffle

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -14,6 +14,9 @@ pullapprove_conditions:
 - condition: "'on hold' not in labels"
   unmet_status: pending
   explanation: "PR review is on hold"
+- condition: "'*[tT]ravis*' in check_runs.pending"
+  unmet_status: pending
+  explanation: "Travis CI tests must complete before review starts"
 - condition: "'*[tT]ravis*' in check_runs.successful"
   unmet_status: failure
   explanation: "Travis CI tests must pass before review starts"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -14,9 +14,6 @@ pullapprove_conditions:
 - condition: "'on hold' not in labels"
   unmet_status: pending
   explanation: "PR review is on hold"
-- condition: "'*[tT]ravis*' in check_runs.pending"
-  unmet_status: pending
-  explanation: "Travis CI tests must complete before review starts"
 - condition: "'*[tT]ravis*' in check_runs.successful"
   unmet_status: failure
   explanation: "Travis CI tests must pass before review starts"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -43,7 +43,9 @@ groups:
     reviewers:
       users:
       - ESapenaVentura
-      - rolando-ebi
+      - aaclan-ebi
+      - jacobwindsor
+      - yusra-haider
     reviews:
       required: 1
       request_order: shuffle
@@ -62,11 +64,12 @@ groups:
       - rays22
       - ami-day
       - ami-day
+      - Wkt8
+      - Wkt8
       - mshadbolt
       - willrockout
       - pnejad
       - ESapenaVentura
-      - claymfischer
     reviews:  # settings for approval and reviewer selection
       required: 2
       request_order: shuffle  # reviewers will be chosen in a random order
@@ -85,11 +88,12 @@ groups:
         - rays22
         - ami-day
         - ami-day
+        - Wkt8
+        - Wkt8
         - mshadbolt
         - willrockout
         - pnejad
         - ESapenaVentura
-        - claymfischer
     reviews:
       required: 1
       request_order: shuffle
@@ -105,6 +109,7 @@ groups:
       - ESapenaVentura
       - rays22
       - ami-day
+      - Wkt8
     reviews:
       required: 1
       request_order: shuffle

--- a/src/schema_linter.py
+++ b/src/schema_linter.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
     # define the proper OLS API URL.
     arguments = argument_parser().parse_args(sys.argv[1:])
     environment = OLS_ENVIRONMENT[arguments.environment]
-    ols_api = 'https://ontology.{}.data.humancellatlas.org/api'.format(environment)
+    ols_api = 'https://ontology.{}.archive.data.humancellatlas.org/api'.format(environment)
 
     schema_path = '../json_schema' if cwd == 'src' else 'json_schema'
     jsons = [os.path.join(dirpath, f)

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -101,7 +101,7 @@ describe ('Testing example data validates against schemas', function () {
                     }
                 });
 
-            })
+            }).timeout(10000)
 
     });
 

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -18,7 +18,7 @@ let baseSchemaPath = path.join(__dirname, '..', schemaDirs);
 // set the example data path
 let baseDataPath = path.join(__dirname, '..', exampleDataDirs);
 
-let ajvOptions = {baseSchemaPath: baseSchemaPath, extendRefs: true, olsApiBaseUrl: 'http://ontology.dev.data.humancellatlas.org/api'};
+let ajvOptions = {baseSchemaPath: baseSchemaPath, extendRefs: true, olsApiBaseUrl: 'http://ontology.archive.data.humancellatlas.org/api'};
 
 let validator = new ElixirValidator([GraphRestriction], ajvOptions);
 var ajv = new Ajv(ajvOptions);


### PR DESCRIPTION
When doing a recent PR to schemas we noticed travis tests were failing. I have updated the ontology url as I think that was causing it to fail. I also increased the timeout time as that was causing it to fail too when run locally. Tests now appear to pass locally.

I am not sure if this fix could be incorporated into the other recent PR (#1339) or if it is better to merge this first to enable the the travis tests to succeed for ongoing schema updates.

We are also using this PR to update the pullapprove config so that the correct users are specified for reviews and notifications.

### Reviews requested

- Need 1 Reviewers to approve because this is not a change to the schemas
- Last Reviewer to review/approve, merge changes by 24 Feb 2021