### PR TITLE
Add identifier, url modules and fields to type/project, Fixes #1336

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -7,6 +7,17 @@ Property name | Description | Type | Required? | Example
  describedBy | The URL reference to the schema. | string | no |  |  |  | 
 schema_version | The version number of the schema in major.minor.patch format. | string | no | 4.6.1
 
+## External Identifier<a name='External Identifier'></a>
+_Information about an external identifier._
+
+Location: module/external_identifier.json
+
+Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- | --- 
+external_identifier | Any unique identifier that identifies the project, dataset, experiment, biomaterial or protocol. | string | yes |  | External Identifier |  | SCP464; E-MTAB-8901
+identifier_source | The source of the unique identifier. | string | yes |  | Identifer Source | insdc_study, insdc_project, insdc_sample, insdc_experiment, biosamples, indsc_run, ega_study, ega_dataset, ega_sample, arrayexpress, scea, scp, geo_series, dbgap, cbtm, hdbr, biostudies, other | 
+other_explanation | An explanation of the source of the identifier. | string | no |  | Other explanation |  | Identifier used for internal tracking.
+
 ## Channel<a name='Channel'></a>
 _Information about a single microscope channel._
 
@@ -324,6 +335,17 @@ Property name | Description | Type | Required? | Object reference? | User friend
 grant_title | The name of the grant funding the project. | string | no |  | Grant title |  | Study of single cells in the human body.
 grant_id | The unique grant identifier or reference. | string | yes |  | Grant ID |  | BB/P0000001/1
 organization | The name of the funding organization. | string | yes |  | Funding organization |  | Biotechnology and Biological Sciences Research Council (BBSRC); California Institute of Regenerative Medicine (CIRM)
+
+## URL<a name='URL'></a>
+_Description of a url related to a project._
+
+Location: module/project/url.json
+
+Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- | --- 
+url | The full url of the website that relates to the project. | string | yes |  | Url |  | https://www.heartcellatlas.org/
+url_type | The type of url specified. | array | yes |  | URL type |  | 
+other_explanation | An explanation of the source of the 'other' url type. | string | no |  | Other explanation |  | Link to protocol information.
 
 ## Contact<a name='Contact'></a>
 _Information about an individual who submitted or contributed to a project._

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -202,6 +202,11 @@ timestamp_stop_utc | Terminal stop time of the full pipeline in UTC. | string | 
 analysis_run_type | Whether the analysis was run or was copied forward as an optimization. | string |  | Analysis run type | run, copy-forward | Should be one of: run, or copy-forward.
 reference_files | UUID of the file entities that contain the reference genome used in running the pipeline. | array |  | Reference files |  | 
 ## Module
+### External Identifier<a name='External Identifier'></a>
+Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- 
+external_identifier | Any unique identifier that identifies the project, dataset, experiment, biomaterial or protocol. | string |  | External Identifier |  | SCP464; E-MTAB-8901
+identifier_source | The source of the unique identifier. | string |  | Identifer Source | insdc_study, insdc_project, insdc_sample, insdc_experiment, biosamples, indsc_run, ega_study, ega_dataset, ega_sample, arrayexpress, scea, scp, geo_series, dbgap, cbtm, hdbr, biostudies, other | 
 ### Channel<a name='Channel'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
@@ -321,6 +326,11 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 grant_id | The unique grant identifier or reference. | string |  | Grant ID |  | BB/P0000001/1
 organization | The name of the funding organization. | string |  | Funding organization |  | Biotechnology and Biological Sciences Research Council (BBSRC); California Institute of Regenerative Medicine (CIRM)
+### URL<a name='URL'></a>
+Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- 
+url | The full url of the website that relates to the project. | string |  | Url |  | https://www.heartcellatlas.org/
+url_type | The type of url specified. | array |  | URL type |  | 
 ### Contact<a name='Contact'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -290,6 +290,8 @@ schema_type | The type of the metadata schema entity. | string | yes |  |  | pro
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
 project_core | Core project-level information. | object | yes | [See core  project_core](core.md/#project_core) | Project core |  | 
 contributors | People contributing to any aspect of the project. | array | no | [See module  contact](module.md/#contact) | Contributors |  | 
+project_accessions | Accessions relating to the project. | array | no | [See module  external_identifier](module.md/#external_identifier) | Project accessions |  | 
+project_urls | A website that relates to the project | array | no | [See module  url](module.md/#url) | Project url |  | 
 supplementary_links | External link(s) pointing to code, supplementary data files, or analysis files associated with the project which will not be uploaded. | array | no |  | Supplementary link(s) |  | https://github.com/czbiohub/tabula-muris; http://celltag.org/
 publications | Publications resulting from this project. | array | no | [See module  publication](module.md/#publication) | Publications |  | 
 insdc_project_accessions | An International Nucleotide Sequence Database Collaboration (INSDC) project accession. | array | no |  | INSDC project accession |  | SRP000000

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -123,7 +123,7 @@
                 "properties": { "identifier_source": { "const": "arrayexpress" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-[0-9]+$" } }
               }
             },
             {
@@ -131,7 +131,7 @@
                 "properties": { "identifier_source": { "const": "scea" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-[0-9]+$" } }
               }
             },
             {
@@ -139,7 +139,7 @@
                 "properties": { "identifier_source": { "const": "scp" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^SCP\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^SCP[0-9]+$" } }
               }
             },
             {
@@ -147,7 +147,7 @@
                 "properties": { "identifier_source": { "const": "geo_series" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^GSE\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^GSE[0-9]+$" } }
               }
             },
             {
@@ -163,7 +163,7 @@
                 "properties": { "identifier_source": { "const": "cbtm" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^\d{3}\w+$" } }
+                "properties": { "external_identifier": { "pattern": "^[0-9]{3}\w+$" } }
               }
             },
             {
@@ -171,7 +171,7 @@
                 "properties": { "identifier_source": { "const": "hdbr" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^[0-9]+$" } }
               }
             },
             {
@@ -179,7 +179,7 @@
                 "properties": { "identifier_source": { "const": "biostudies" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}\d+$" } }
+                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}[0-9]+$" } }
               }
             },
             {

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -13,12 +13,12 @@
         "describedBy": {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/funder"
+            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/((\\d{1,}.\\d{1,}.\\d{1,})|([a-zA-Z]*?))/funder"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",
             "type": "string",
-            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "pattern": "^\\d{1,}.\\d{1,}.\\d{1,}$",
             "example": "4.6.1"
         },
         "external_identifier": {
@@ -56,18 +56,18 @@
               "if": {
                 "properties": {"identifier_source": {"const": "insdc_study"}}},
               "then": {
-                "properties": {"external_identifier": {"pattern": "^(E|D|S)RP[0-9]{6,}$"}}}},
+                "properties": {"external_identifier": {"pattern": "^(E|D|S)RP\\d{6,}$"}}}},
             {
               "if": {
                 "properties": { "identifier_source": { "const": "insdc_project" }}},
               "then": {
-                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z][0-9]+$" }}}},
+                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z\\d+$" }}}},
             {
               "if": {
                 "properties": { "identifier_source": { "const": "insdc_sample" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RS[0-9]{6,}$" } }
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RS\\d{6,}$" } }
               }
             },
             {
@@ -75,7 +75,7 @@
                 "properties": { "identifier_source": { "const": "insdc_experiment" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RX[0-9]{6,}$" } }
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RX\\d{6,}$" } }
               }
             },
             {
@@ -83,7 +83,7 @@
                 "properties": { "identifier_source": { "const": "insdc_run" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RR[0-9]{6,}$" } }
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RR\\d{6,}$" } }
               }
             },
             {
@@ -91,7 +91,7 @@
                 "properties": { "identifier_source": { "const": "biosamples" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^SAM(E|D|N)[A-Z]?[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^SAM(E|D|N)[A-Z]?\\d+$" } }
               }
             },
             {
@@ -99,7 +99,7 @@
                 "properties": { "identifier_source": { "const": "ega_study" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAS\d{11}$" } }
+                "properties": { "external_identifier": { "pattern": "^EGAS\\d{11}$" } }
               }
             },
             {
@@ -107,7 +107,7 @@
                 "properties": { "identifier_source": { "const": "ega_dataset" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAD\d{11}$" } }
+                "properties": { "external_identifier": { "pattern": "^EGAD\\d{11}$" } }
               }
             },
             {
@@ -115,7 +115,7 @@
                 "properties": { "identifier_source": { "const": "ega_sample" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAN\d{11}$" } }
+                "properties": { "external_identifier": { "pattern": "^EGAN\\d{11}$" } }
               }
             },
             {
@@ -123,7 +123,7 @@
                 "properties": { "identifier_source": { "const": "arrayexpress" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\\d+$" } }
               }
             },
             {
@@ -131,7 +131,7 @@
                 "properties": { "identifier_source": { "const": "scea" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\\d+$" } }
               }
             },
             {
@@ -139,7 +139,7 @@
                 "properties": { "identifier_source": { "const": "scp" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^SCP[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^SCP\\d+$" } }
               }
             },
             {
@@ -147,7 +147,7 @@
                 "properties": { "identifier_source": { "const": "geo_series" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^GSE[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^GSE\\d+$" } }
               }
             },
             {
@@ -155,7 +155,7 @@
                 "properties": { "identifier_source": { "const": "dbgap" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^phs[0-9]{6}(\\.v[0-9]{1})?(\\.p[0-9])?$" } }
+                "properties": { "external_identifier": { "pattern": "^phs\\d{6}(\\.v\\d{1})?(\\.p\\d)?$" } }
               }
             },
             {
@@ -163,7 +163,7 @@
                 "properties": { "identifier_source": { "const": "cbtm" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^[0-9]{3}\w+$" } }
+                "properties": { "external_identifier": { "pattern": "^\\d{3}\w+$" } }
               }
             },
             {
@@ -171,7 +171,7 @@
                 "properties": { "identifier_source": { "const": "hdbr" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^\\d+$" } }
               }
             },
             {
@@ -179,7 +179,7 @@
                 "properties": { "identifier_source": { "const": "biostudies" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}[0-9]+$" } }
+                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}\\d+$" } }
               }
             },
             {

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -1,205 +1,355 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Information about an external identifier.",
-    "additionalProperties": false,
-    "required": [
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "description":"Information about an external identifier.",
+    "additionalProperties":false,
+    "required":[
         "external_identifier",
         "identifier_source"
     ],
-    "title": "External Identifier",
-    "name": "external_identifier",
-    "type": "object",
-    "properties": {
-        "describedBy": {
-            "description": "The URL reference to the schema.",
-            "type": "string",
-            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/((\\d{1,}.\\d{1,}.\\d{1,})|([a-zA-Z]*?))/funder"
+    "title":"External Identifier",
+    "name":"external_identifier",
+    "type":"object",
+    "properties":{
+        "describedBy":{
+            "description":"The URL reference to the schema.",
+            "type":"string",
+            "pattern":"^(http|https)://schema.(.*?)humancellatlas.org/module/project/((\\d{1,}.\\d{1,}.\\d{1,})|([a-zA-Z]*?))/funder"
         },
-        "schema_version": {
-            "description": "The version number of the schema in major.minor.patch format.",
-            "type": "string",
-            "pattern": "^\\d{1,}.\\d{1,}.\\d{1,}$",
-            "example": "4.6.1"
+        "schema_version":{
+            "description":"The version number of the schema in major.minor.patch format.",
+            "type":"string",
+            "pattern":"^\\d{1,}.\\d{1,}.\\d{1,}$",
+            "example":"4.6.1"
         },
-        "external_identifier": {
-            "description": "Any unique identifier that identifies the project, dataset, experiment, biomaterial or protocol.",
-            "type": "string",
-            "example": "SCP464; E-MTAB-8901",
-            "user_friendly": "External Identifier",
-            "guidelines": "Enter an identifier including and accession from one of the listed sources. If source not present, select 'other'."
+        "external_identifier":{
+            "description":"Any unique identifier that identifies the project, dataset, experiment, biomaterial or protocol.",
+            "type":"string",
+            "example":"SCP464; E-MTAB-8901",
+            "user_friendly":"External Identifier",
+            "guidelines":"Enter an identifier including and accession from one of the listed sources. If source not present, select 'other'."
         },
-        "identifier_source": {
-            "description": "The source of the unique identifier.",
-            "type": "string",
-            "enum": [
-              "insdc_study",
-              "insdc_project",
-              "insdc_sample",
-              "insdc_experiment",
-              "biosamples",
-              "indsc_run",
-              "ega_study",
-              "ega_dataset",
-              "ega_sample",
-              "arrayexpress",
-              "scea",
-              "scp",
-              "geo_series",
-              "dbgap",
-              "cbtm",
-              "hdbr",
-              "biostudies",
-              "other"
+        "identifier_source":{
+            "description":"The source of the unique identifier.",
+            "type":"string",
+            "enum":[
+                "insdc_study",
+                "insdc_project",
+                "insdc_sample",
+                "insdc_experiment",
+                "biosamples",
+                "indsc_run",
+                "ega_study",
+                "ega_dataset",
+                "ega_sample",
+                "arrayexpress",
+                "scea",
+                "scp",
+                "geo_series",
+                "dbgap",
+                "cbtm",
+                "hdbr",
+                "biostudies",
+                "other"
             ],
-          "allOf": [
-            {
-              "if": {
-                "properties": {"identifier_source": {"const": "insdc_study"}}},
-              "then": {
-                "properties": {"external_identifier": {"pattern": "^(E|D|S)RP\\d{6,}$"}}}},
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "insdc_project" }}},
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z]\\d+$" }}}},
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "insdc_sample" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RS\\d{6,}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "insdc_experiment" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RX\\d{6,}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "insdc_run" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^(E|D|S)RR\\d{6,}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "biosamples" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^SAM(E|D|N)[A-Z]?\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "ega_study" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAS\\d{11}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "ega_dataset" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAD\\d{11}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "ega_sample" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^EGAN\\d{11}$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "arrayexpress" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "scea" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "scp" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^SCP\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "geo_series" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^GSE\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "dbgap" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^phs\\d{6}(\\.v\\d{1})?(\\.p\\d)?$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "cbtm" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^\\d{3}\\w+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "hdbr" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "biostudies" } }
-              },
-              "then": {
-                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}\\d+$" } }
-              }
-            },
-            {
-              "if": {
-                "properties": { "identifier_source": { "const": "other" } }
-              },
-              "then": {
-                "properties": { "other_explanation": { "pattern": "[a-zA-Z]+" } }
-              }
-            }
-          ],
-          "user_friendly": "Identifer Source",
-          "guidelines": "Choose the source of the identifier, if source isn't listed select 'other'"
+            "user_friendly":"Identifer Source",
+            "guidelines":"Choose the source of the identifier, if source isn't listed select 'other'"
         },
-        "other_explanation": {
-            "description": "An explanation of the source of the identifier.",
-            "type": "string",
-            "example": "Identifier used for internal tracking.",
-            "user_friendly": "Other explanation",
-            "guidelines": "If you selected 'other' explain the source of the identifier."
+        "other_explanation":{
+            "description":"An explanation of the source of the identifier.",
+            "type":"string",
+            "example":"Identifier used for internal tracking.",
+            "user_friendly":"Other explanation",
+            "guidelines":"If you selected 'other' explain the source of the identifier."
         }
-    }
+    },
+    "allOf":[
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"insdc_study"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^(E|D|S)RP\\d{6,}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"insdc_project"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^PRJ(E|D|N)[A-Z]\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"insdc_sample"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^(E|D|S)RS\\d{6,}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"insdc_experiment"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^(E|D|S)RX\\d{6,}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"insdc_run"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^(E|D|S)RR\\d{6,}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"biosamples"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^SAM(E|D|N)[A-Z]?\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"ega_study"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^EGAS\\d{11}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"ega_dataset"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^EGAD\\d{11}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"ega_sample"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^EGAN\\d{11}$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"arrayexpress"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^E-[A-Z]{4}-\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"scea"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^E-[A-Z]{4}-\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"scp"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^SCP\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"geo_series"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^GSE\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"dbgap"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^phs\\d{6}(\\.v\\d{1})?(\\.p\\d)?$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"cbtm"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^\\d{3}\\w+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"hdbr"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"biostudies"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "external_identifier":{
+                        "pattern":"^S-[A-Z]{4}\\d+$"
+                    }
+                }
+            }
+        },
+        {
+            "if":{
+                "properties":{
+                    "identifier_source":{
+                        "const":"other"
+                    }
+                }
+            },
+            "then":{
+                "properties":{
+                    "other_explanation":{
+                        "pattern":"[a-zA-Z]+"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -61,7 +61,7 @@
               "if": {
                 "properties": { "identifier_source": { "const": "insdc_project" }}},
               "then": {
-                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z\\d+$" }}}},
+                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z]\\d+$" }}}},
             {
               "if": {
                 "properties": { "identifier_source": { "const": "insdc_sample" } }
@@ -163,7 +163,7 @@
                 "properties": { "identifier_source": { "const": "cbtm" } }
               },
               "then": {
-                "properties": { "external_identifier": { "pattern": "^\\d{3}\w+$" } }
+                "properties": { "external_identifier": { "pattern": "^\\d{3}\\w+$" } }
               }
             },
             {

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -191,15 +191,15 @@
               }
             }
           ],
-          "other_explanation": {
+          "user_friendly": "Identifer Source",
+          "guidelines": "Choose the source of the identifier, if source isn't listed select 'other'"
+        },
+        "other_explanation": {
             "description": "An explanation of the source of the identifier.",
             "type": "string",
             "example": "Identifier used for internal tracking.",
             "user_friendly": "Other explanation",
             "guidelines": "If you selected 'other' explain the source of the identifier."
-          },
-          "user_friendly": "Identifer Source",
-          "guidelines": "Choose the source of the identifier, if source isn't listed select 'other'"
         }
     }
 }

--- a/json_schema/module/external_identifier.json
+++ b/json_schema/module/external_identifier.json
@@ -1,0 +1,205 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Information about an external identifier.",
+    "additionalProperties": false,
+    "required": [
+        "external_identifier",
+        "identifier_source"
+    ],
+    "title": "External Identifier",
+    "name": "external_identifier",
+    "type": "object",
+    "properties": {
+        "describedBy": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/funder"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "external_identifier": {
+            "description": "Any unique identifier that identifies the project, dataset, experiment, biomaterial or protocol.",
+            "type": "string",
+            "example": "SCP464; E-MTAB-8901",
+            "user_friendly": "External Identifier",
+            "guidelines": "Enter an identifier including and accession from one of the listed sources. If source not present, select 'other'."
+        },
+        "identifier_source": {
+            "description": "The source of the unique identifier.",
+            "type": "string",
+            "enum": [
+              "insdc_study",
+              "insdc_project",
+              "insdc_sample",
+              "insdc_experiment",
+              "biosamples",
+              "indsc_run",
+              "ega_study",
+              "ega_dataset",
+              "ega_sample",
+              "arrayexpress",
+              "scea",
+              "scp",
+              "geo_series",
+              "dbgap",
+              "cbtm",
+              "hdbr",
+              "biostudies",
+              "other"
+            ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {"identifier_source": {"const": "insdc_study"}}},
+              "then": {
+                "properties": {"external_identifier": {"pattern": "^(E|D|S)RP[0-9]{6,}$"}}}},
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "insdc_project" }}},
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^PRJ(E|D|N)[A-Z][0-9]+$" }}}},
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "insdc_sample" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RS[0-9]{6,}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "insdc_experiment" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RX[0-9]{6,}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "insdc_run" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^(E|D|S)RR[0-9]{6,}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "biosamples" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^SAM(E|D|N)[A-Z]?[0-9]+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "ega_study" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^EGAS\d{11}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "ega_dataset" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^EGAD\d{11}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "ega_sample" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^EGAN\d{11}$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "arrayexpress" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "scea" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^E-[A-Z]{4}-\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "scp" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^SCP\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "geo_series" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^GSE\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "dbgap" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^phs[0-9]{6}(\\.v[0-9]{1})?(\\.p[0-9])?$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "cbtm" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^\d{3}\w+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "hdbr" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "biostudies" } }
+              },
+              "then": {
+                "properties": { "external_identifier": { "pattern": "^S-[A-Z]{4}\d+$" } }
+              }
+            },
+            {
+              "if": {
+                "properties": { "identifier_source": { "const": "other" } }
+              },
+              "then": {
+                "properties": { "other_explanation": { "pattern": "[a-zA-Z]+" } }
+              }
+            }
+          ],
+          "other_explanation": {
+            "description": "An explanation of the source of the identifier.",
+            "type": "string",
+            "example": "Identifier used for internal tracking.",
+            "user_friendly": "Other explanation",
+            "guidelines": "If you selected 'other' explain the source of the identifier."
+          },
+          "user_friendly": "Identifer Source",
+          "guidelines": "Choose the source of the identifier, if source isn't listed select 'other'"
+        }
+    }
+}

--- a/json_schema/module/project/url.json
+++ b/json_schema/module/project/url.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Description of a url related to a project.",
+    "additionalProperties": false,
+    "required": [
+        "url",
+        "url_type"
+    ],
+    "title": "URL",
+    "name": "url",
+    "type": "object",
+    "properties": {
+      "describedBy": {
+        "description": "The URL reference to the schema.",
+        "type": "string",
+        "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/core/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/project_core"
+      },
+      "schema_version": {
+        "description": "The version number of the schema in major.minor.patch format.",
+        "type": "string",
+        "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+        "example": "4.6.1"
+      },
+      "url": {
+        "description": "The full url of the website that relates to the project.",
+        "type": "string",
+        "example": "https://www.heartcellatlas.org/",
+        "pattern": "^https?://.+",
+        "user_friendly": "Url",
+        "guidelines": "Enter the full url including http|s. Should not be an accession based link."
+      },
+      "url_type": {
+        "description": "The type of url specified.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "analysis portal",
+            "code repository",
+            "data repository",
+            "other"
+          ]
+        },
+        "user_friendly": "URL type",
+        "guidelines": "Specify as many types as applicable, if no appropriate type specified, choose 'other'."
+      },
+      "other_explanation": {
+        "description": "An explanation of the source of the 'other' url type.",
+        "type": "string",
+        "example": "Link to protocol information.",
+        "user_friendly": "Other explanation",
+        "guidelines": "If you selected 'other', describe the source of the identifier."
+      }
+    }
+}

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -49,6 +49,22 @@
             },
             "user_friendly": "Contributors"
         },
+        "project_accessions": {
+            "description": "Accessions relating to the project.",
+            "type": "array",
+            "items": {
+                "$ref": "module/external_identifier.json"
+            },
+            "user_friendly": "Project accessions"
+        },
+        "project_urls": {
+            "description": "A website that relates to the project",
+            "type": "array",
+            "items": {
+                "$ref": "module/project/url.json"
+            },
+            "user_friendly": "Project url"
+        },
         "supplementary_links": {
             "description": "External link(s) pointing to code, supplementary data files, or analysis files associated with the project which will not be uploaded.",
             "type": "array",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,3 +1,4 @@
 Schema,Change type,Change message,Version,Date
 module/external_identifier,major,"Added the schema",,
 module/project/url,major,"Added the schema",,
+type/project/project,minor,"Added optional project_accessions, project_urls fields",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,3 @@
 Schema,Change type,Change message,Version,Date
+module/external_identifier,major,"Added the schema",,
+module/project/url,major,"Added the schema",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -70,12 +70,14 @@
             "project": {
                 "contact": "8.0.1",
                 "funder": "2.0.0",
-                "publication": "6.0.0"
+                "publication": "6.0.0",
+                "url": "0.0.0"
             },
             "protocol": {
                 "channel": "2.0.4",
                 "probe": "1.1.1"
-            }
+            },
+            "external_identifier": "0.0.0"
         },
         "system": {
             "file_descriptor": "2.0.0",

--- a/src/schema_linter.py
+++ b/src/schema_linter.py
@@ -16,7 +16,7 @@ cwd = os.getcwd().split("/")[-1]
 
 required_schema_fields = ['$schema', 'description', 'additionalProperties', 'title', 'name', 'type', 'properties']
 
-allowed_schema_fields = ['$schema', 'description', 'additionalProperties', 'required', 'title', 'name', 'type', 'properties', 'definitions']
+allowed_schema_fields = ['$schema', 'description', 'additionalProperties', 'required', 'title', 'name', 'type', 'properties', 'definitions', 'allOf']
 
 # Properties
 

--- a/tests/schema_test_files/project/test_fail_project_0.json
+++ b/tests/schema_test_files/project/test_fail_project_0.json
@@ -1,6 +1,6 @@
 {
-  "describedBy": "https://schema.dev.data.humancellatlas.org/type/project/5.1.0/project",
-  "schema_version": "5.1.0",
+  "describedBy": "https://schema.dev.data.humancellatlas.org/type/project/10.1.0/project",
+  "schema_version": "10.1.0",
   "schema_type": "project",
   "project_core": {
     "project_title": "Project 1",
@@ -18,6 +18,12 @@
     {
       "grant_id": "BB/P0000001/1",
       "organization": "Biotechnology and Biological Sciences Research Council (BBSRC)"
+    }
+  ],
+  "project_accessions": [
+    {
+      "external_identifier": "F1",
+      "identifier_source": "other"
     }
   ]
 }

--- a/tests/schema_test_files/project/test_pass_project_0.json
+++ b/tests/schema_test_files/project/test_pass_project_0.json
@@ -1,6 +1,6 @@
 {
-  "describedBy": "https://schema.dev.data.humancellatlas.org/type/project/5.1.0/project",
-  "schema_version": "5.1.0",
+  "describedBy": "https://schema.dev.data.humancellatlas.org/type/project/10.1.0/project",
+  "schema_version": "10.1.0",
   "schema_type": "project",
   "project_core": {
     "project_short_name": "P1",
@@ -19,6 +19,33 @@
     {
       "grant_id": "BB/P0000001/1",
       "organization": "Biotechnology and Biological Sciences Research Council (BBSRC)"
+    }
+  ],
+  "project_accessions": [
+    {
+      "external_identifier": "ERP121750",
+      "identifier_source": "insdc_study"
+    },
+    {
+      "external_identifier": "PRJEB38334",
+      "identifier_source": "insdc_project"
+    },
+    {
+      "external_identifier": "E-MTAB-9067",
+      "identifier_source": "arrayexpress"
+    },
+    {
+      "external_identifier": "GSE166766",
+      "identifier_source": "geo_series"
+    },
+    {
+      "external_identifier": "phs001997.v1.p1",
+      "identifier_source": "dbgap"
+    },
+    {
+      "external_identifier": "F1",
+      "identifier_source": "other",
+      "other_explanation": "donor identifier used in pub"
     }
   ]
 }


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

I am making this PR as a starting point to get feedback. I am not sure if we want to remove all the existing accession and links fields yet or if we want to have a soft transition while we figure out a plan of migration. 

### Release notes

Created External Identifier module as a non typed module

Created URL module as a project module

For type/project schema:
- added optional project_accessions field
- added optional project_urls field

### Reviews requested

- Need 2 Reviewers to approve because this is a major update
- Last Reviewer to review/approve, merge changes by Friday, 5th March
