### PR TITLE
Add HCA publication status to publications module, fixes #1345

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -31,7 +31,7 @@ notifications:
   if: "'content' in labels and 'major' in body" # Notify the DCP for a major update
   comment: |
     Major metadata schema update, pinging @aaclan-ebi @NoopDog
-    @hannes-ucsc @danxmoran . If no one objects, this will be merged on the
+    @hannes-ucsc @aherbst-broad . If no one objects, this will be merged on the
     following 5 working days.
 
 groups:

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -355,6 +355,7 @@ title | The title of the publication. | string | yes |  | Publication title |  |
 doi | The publication digital object identifier (doi) of the publication. | string | no |  | Publication DOI |  | 10.1016/j.cell.2016.07.054
 pmid | The PubMed ID of the publication. | integer | no |  | Publication PMID |  | 27565351
 url | A URL for the publication. | string | no |  | Publication URL |  | https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/
+hca_publication_status | Has the publication been accepted as an official HCA publication according to the process at https://www.humancellatlas.org/publications/ | boolean | no |  | HCA Publication? |  | yes; no
 
 ## Human-specific<a name='Human-specific'></a>
 _Information specific to a donor that is a human (Homo sapiens)._

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -54,6 +54,13 @@
             "type": "string",
             "user_friendly": "Publication URL",
             "example": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/"
+        },
+        "hca_publication_status": {
+            "description": "Has the publication been accepted as an official HCA publication according to the process at https://www.humancellatlas.org/publications/",
+            "type": "boolean",
+            "user_friendly": "HCA Publication?",
+            "guidelines": "Should be one of yes or no",
+            "example": "yes; no"
         }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,2 @@
 Schema,Change type,Change message,Version,Date
-module/publication,minor,"Added optional hca_publication_status field",,
+module/publication,minor,"Added optional hca_publication_status field. Fixes #1345",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+module/publication,minor,"Added optional hca_publication_status field",,


### PR DESCRIPTION
### Release notes

For module/publications.json schema:
- added optional hca_publication_status field
 
### Reviews requested

- Need 2 Reviewers to approve because this is a minor update
- Last Reviewer to review/approve, merge changes by Friday, 5th March
