### PR TITLE
Fixes regex issue in CGMs test data 

### DIFF
--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -20,7 +20,7 @@
     "describedBy": {
       "description": "The URL reference to the schema.",
       "type": "string",
-      "pattern" : "^https?://schema(\\.[a-z]+)?\\.humancellatlas\\.org/system/(([0-9]{1,}\\.[0-9]{1,}\\.[0-9]{1,})|([a-zA-Z]*?))/file_descriptor$"
+      "pattern" : "^https?://schema.(.*)?.humancellatlas.org/system/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/file_descriptor$"
     },
     "schema_version": {
       "description": "The version number of the schema in major.minor.patch format.",


### PR DESCRIPTION
Fixes regex issue in https://github.com/HumanCellAtlas/schema-test-data/pull/8/files 

### Release notes
For system/file_descriptor schema:
- changed regex on the DescribedBy field to allow for pointing to staging schemas 

### Reviews requested

- Need 1 Reviewers to approve because this is a patch update
- Last Reviewer to review/approve, merge changes by 30/04/21
