### PR TITLE
Linted matrix schema.

### DIFF
--- a/json_schema/module/protocol/matrix.json
+++ b/json_schema/module/protocol/matrix.json
@@ -35,7 +35,7 @@
                 "Downsampling",
                 "other",
                 "unknown"
-            ]
+                ]
             },
             "guidelines": "Should be one of: CPM (counts per million), TPM (transcripts per kilobase million), RPKM(reads per kilobase of exon per million reads mapped), FPKM (fragments per kilobase of exon per million fragments mapped), DESeq2’s median of ratios, TMM (EdgeR’s trimmed mean of M values), SF (size factor), UQ (Upper quartile), Downsampling, unknown, other."
         },

--- a/json_schema/module/protocol/matrix.json
+++ b/json_schema/module/protocol/matrix.json
@@ -21,7 +21,7 @@
             "description": "Method(s) used to normalize data in the matrix",
             "type": "array",
             "user_friendly": "Data normalization method(s)",
-            "items":{
+            "items": {
                 "type": "string",
                 "enum": [
                 "CPM (counts per million)",


### PR DESCRIPTION
### Release notes

For json_schema/module/protocol/matrix schema:
- L24: Added missing space between `:` and `{`
- L38: Added tabulation to be consistent with the opening of the list
- Added newline at the end of file
 

### Reviews requested

- Need 1 Reviewers to approve because this is not any type of semantic update
