### PR TITLE
Fixed typo on apostrophe from enum. Fixes #1410

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -46,7 +46,7 @@ Location: module/protocol/matrix.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-data_normalization_methods | Method(s) used to normalize data in the matrix | array | no |  | Data normalization method(s) | CPM (counts per million), TPM (transcripts per kilobase million), RPKM (reads per kilobase of exon per million reads mapped), FPKM (fragments per kilobase of exon per million fragments mapped), DESeq2’s median of ratios, TMM (EdgeR’s trimmed mean of M values), SF (size factor), UQ (Upper quartile), Downsampling, other, unknown | 
+data_normalization_methods | Method(s) used to normalize data in the matrix | array | no |  | Data normalization method(s) | CPM (counts per million), TPM (transcripts per kilobase million), RPKM (reads per kilobase of exon per million reads mapped), FPKM (fragments per kilobase of exon per million fragments mapped), DESeq2's median of ratios, TMM (EdgeR's trimmed mean of M values), SF (size factor), UQ (Upper quartile), Downsampling, other, unknown | 
 derivation_process | Type of computational tool used in generating the matrix object. | array | no |  | Derivation process | alignment, quantification, peak calling, peak annotation, gene filtering, cell filtering, merging, cell calling, ambient RNA correction, doublet removal, batch correction, depth normalization, other | 
 
 ## File content ontology<a name='File content ontology'></a>

--- a/json_schema/module/protocol/matrix.json
+++ b/json_schema/module/protocol/matrix.json
@@ -28,8 +28,8 @@
                   "TPM (transcripts per kilobase million)",
                   "RPKM (reads per kilobase of exon per million reads mapped)",
                   "FPKM (fragments per kilobase of exon per million fragments mapped)",
-                  "DESeq2’s median of ratios",
-                  "TMM (EdgeR’s trimmed mean of M values)",
+                  "DESeq2's median of ratios",
+                  "TMM (EdgeR's trimmed mean of M values)",
                   "SF (size factor)",
                   "UQ (Upper quartile)",
                   "Downsampling",
@@ -37,7 +37,7 @@
                   "unknown"
                 ]
             },
-            "guidelines": "Should be one of: CPM (counts per million), TPM (transcripts per kilobase million), RPKM(reads per kilobase of exon per million reads mapped), FPKM (fragments per kilobase of exon per million fragments mapped), DESeq2’s median of ratios, TMM (EdgeR’s trimmed mean of M values), SF (size factor), UQ (Upper quartile), Downsampling, unknown, other."
+            "guidelines": "Should be one of: CPM (counts per million), TPM (transcripts per kilobase million), RPKM(reads per kilobase of exon per million reads mapped), FPKM (fragments per kilobase of exon per million fragments mapped), DESeq2's median of ratios, TMM (EdgeR's trimmed mean of M values), SF (size factor), UQ (Upper quartile), Downsampling, unknown, other."
         },
         "derivation_process": {
             "description": "Type of computational tool used in generating the matrix object.",


### PR DESCRIPTION
### Release notes

For `module/protocol/matrix.json` schema:
- Fixed right single quotation mark used for enum values and example
 

Related to request https://github.com/HumanCellAtlas/metadata-schema/issues/1410