### PR TITLE
Extended read index enum and barcode read enum. Fixes #1401

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,18 +7,6 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
-### [type/file/sequence_file.json - v9.3.1] - 2021-10-29
-### Added
-Added read3, read4 to read index enum. Fixes #1401
-
-### [module/process/sequencing/barcode.json - v5.2.7] - 2021-10-29
-### Added
-Added Read 3, Read 4 to barcode read enum. Fixes #1401
-
-### [type/protocol/sequencing/library_preparation_protocol.json - v6.2.1] - 2021-10-29
-### Added
-Added Read 3, Read 4 to barcode read enum. Fixes #1401
-
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/project/publication.json - v7.0.0] - 2021-08-13

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,18 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)
 
+### [type/file/sequence_file.json - v9.3.1] - 2021-10-29
+### Added
+Added read3, read4 to read index enum. Fixes #1401
+
+### [module/process/sequencing/barcode.json - v5.2.7] - 2021-10-29
+### Added
+Added Read 3, Read 4 to barcode read enum. Fixes #1401
+
+### [type/protocol/sequencing/library_preparation_protocol.json - v6.2.1] - 2021-10-29
+### Added
+Added Read 3, Read 4 to barcode read enum. Fixes #1401
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/project/publication.json - v7.0.0] - 2021-08-13

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -525,7 +525,7 @@ Location: module/process/sequencing/barcode.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-barcode_read | The read in which the barcode is found. | string | yes |  | Barcode-containing read | Read 1, Read 2, i7 Index, i5 Index | Should be one of: Read 1, Read 2, i7 Index, or i5 Index.
+barcode_read | The read in which the barcode is found. | string | yes |  | Barcode-containing read | Read 1, Read 2, Read 3, Read 4, i7 Index, i5 Index | Should be one of: Read 1, Read 2, i7 Index, or i5 Index.
 barcode_offset | The 0-based offset of start of barcode in read. | integer | yes |  | Barcode offset |  | 0
 barcode_length | Length of barcode in nucleotides. | integer | yes |  | Barcode length |  | 28
 white_list_file | Name of file containing legitimate barcode sequences. | string | no |  | White list barcode file |  | barcode_whitelist_file.txt

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -31,7 +31,7 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | file | 
 file_core | Core file-level information. | object | [See core  file_core](core.md/#file_core) | File core |  | 
-read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
+read_index | The sequencing read this file represents. | string |  | Read index | read1, read2, read3, read4, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
 ### Image file
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
@@ -367,7 +367,7 @@ insdc_experiment_accession | An International Nucleotide Sequence Database Colla
 ### Barcode<a name='Barcode'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
-barcode_read | The read in which the barcode is found. | string |  | Barcode-containing read | Read 1, Read 2, i7 Index, i5 Index | Should be one of: Read 1, Read 2, i7 Index, or i5 Index.
+barcode_read | The read in which the barcode is found. | string |  | Barcode-containing read | Read 1, Read 2, Read 3, Read 4, i7 Index, i5 Index | Should be one of: Read 1, Read 2, i7 Index, or i5 Index.
 barcode_offset | The 0-based offset of start of barcode in read. | integer |  | Barcode offset |  | 0
 barcode_length | Length of barcode in nucleotides. | integer |  | Barcode length |  | 28
 ### 10x-specific<a name='10x-specific'></a>

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -17,7 +17,7 @@ Property name | Description | Type | Required? | Object reference? | User friend
 schema_type | The type of the metadata schema entity. | string | yes |  |  | file | 
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md/#file_core) | File core |  | 
-read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
+read_index | The sequencing read this file represents. | string | yes |  | Read index | read1, read2, read3, read4, index1, index2, single-end, non-indexed | Should be one of: read1, read2, index1, index2
 lane_index | The lane that this file was sequenced from. | integer | no |  | Lane index |  | 1
 read_length | The length of a sequenced read in this file, in nucleotides. | integer | no |  | Read length |  | 51
 insdc_run_accessions | An International Nucleotide Sequence Database Collaboration (INSDC) run accession. | array | no |  | INSDC run accession |  | SRR0000000

--- a/json_schema/module/process/sequencing/barcode.json
+++ b/json_schema/module/process/sequencing/barcode.json
@@ -28,6 +28,8 @@
             "enum": [
                 "Read 1",
                 "Read 2",
+                "Read 3",
+                "Read 4",
                 "i7 Index",
                 "i5 Index"
             ],

--- a/json_schema/type/file/sequence_file.json
+++ b/json_schema/type/file/sequence_file.json
@@ -48,6 +48,8 @@
             "enum": [
                 "read1",
                 "read2",
+                "read3",
+                "read4",
                 "index1",
                 "index2",
                 "single-end, non-indexed"

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,3 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/file/sequence_file,patch,"Added read3, read4 to read index enum. Fixes #1401",,
-module/process/sequencing/barcode,patch,"Added Read 3, Read 4 to barcode read enum. Fixes #1401",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,3 @@
 Schema,Change type,Change message,Version,Date
+type/file/sequence_file,patch,"Added read3, read4 to read index enum. Fixes #1401",,
+module/process/sequencing/barcode,patch,"Added Read 3, Read 4 to barcode read enum. Fixes #1401",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2021-08-13T14:44:48Z",
+    "last_update_date": "2021-10-29T15:46:12Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -62,7 +62,7 @@
                 "purchased_reagents": "6.1.0",
                 "sequencing": {
                     "10x": "1.0.5",
-                    "barcode": "5.2.6",
+                    "barcode": "5.2.7",
                     "insdc_experiment": "2.0.0",
                     "plate_based_sequencing": "3.0.0"
                 }
@@ -97,7 +97,7 @@
                 "analysis_file": "6.3.0",
                 "image_file": "2.3.0",
                 "reference_file": "3.3.0",
-                "sequence_file": "9.3.0",
+                "sequence_file": "9.3.1",
                 "supplementary_file": "2.3.0"
             },
             "process": {
@@ -127,7 +127,7 @@
                 },
                 "protocol": "7.1.0",
                 "sequencing": {
-                    "library_preparation_protocol": "6.2.0",
+                    "library_preparation_protocol": "6.2.1",
                     "sequencing_protocol": "10.1.0"
                 }
             }

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2021-10-29T15:46:12Z",
+    "last_update_date": "2021-08-13T14:44:48Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -62,7 +62,7 @@
                 "purchased_reagents": "6.1.0",
                 "sequencing": {
                     "10x": "1.0.5",
-                    "barcode": "5.2.7",
+                    "barcode": "5.2.6",
                     "insdc_experiment": "2.0.0",
                     "plate_based_sequencing": "3.0.0"
                 }
@@ -97,7 +97,7 @@
                 "analysis_file": "6.3.0",
                 "image_file": "2.3.0",
                 "reference_file": "3.3.0",
-                "sequence_file": "9.3.1",
+                "sequence_file": "9.3.0",
                 "supplementary_file": "2.3.0"
             },
             "process": {
@@ -127,7 +127,7 @@
                 },
                 "protocol": "7.1.0",
                 "sequencing": {
-                    "library_preparation_protocol": "6.2.1",
+                    "library_preparation_protocol": "6.2.0",
                     "sequencing_protocol": "10.1.0"
                 }
             }


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

For type/file/sequence_file and module/process/sequencing/barcode:
- Extended read index enum to include read3 and read4
- Extended barcode read enum to include Read 3 and Read 4 

 

### Reviews requested

- Need 1 reviewer to approve because this is a patch update
- Last Reviewer to review/approve, merge changes by 25th October
