### PR TITLE
Allow inclusion of an external DRS URI in file descriptors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,12 @@ Added Read 3, Read 4 to barcode read enum. Fixes #1401
 ### Added
 Added spatial barcode field loading barcodes module
 
+## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
+
+### [system/file_descriptor.json - v2.1.0] - 2021-03-21
+### Added
+Added optional drs_uri file to file_descriptor
+
 ### [module/project/publication.json - v7.0.0] - 2021-08-13
 ### Added
 Added required official_hca_publication field. Fixes #1345

--- a/changelog.md
+++ b/changelog.md
@@ -39,10 +39,6 @@ Added spatial barcode field loading barcodes module
 
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
-### [system/file_descriptor.json - v2.1.0] - 2021-03-21
-### Added
-Added optional drs_uri file to file_descriptor
-
 ### [module/project/publication.json - v7.0.0] - 2021-08-13
 ### Added
 Added required official_hca_publication field. Fixes #1345

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -97,7 +97,7 @@
     },
     "drs_uri": {
       "description": "Data Repository Service URI pointing at this file. If this property is absent, a data file exists in the repository containing this descriptor. If this property is present and not `null`, a data file exists in another repository at the specified URI. If this property is present but `null`, the data file is not available, but will likely become available in the future, along with an updated descriptor referencing it.",
-      "user_friendly": "DRS URI",
+      "user_friendly": "Data Repository Service URI",
       "type": ["string", "null"],
       "format": "uri",
       "example": "drs://drs.example.org/314159"

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -19,7 +19,8 @@
   "properties": {
     "describedBy": {
       "description": "The URL reference to the schema.",
-      "type": "string"
+      "type": "string",
+      "pattern" : "^https?://schema.(.*)?humancellatlas.org/system/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/file_descriptor$"
     },
     "schema_version": {
       "description": "The version number of the schema in major.minor.patch format.",

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -7,7 +7,11 @@
     "schema_type",
     "file_id",
     "file_version",
-    "file_name"
+    "file_name",
+    "content_type",
+    "size",
+    "sha256",
+    "crc32c"
   ],
   "title": "File descriptor",
   "name": "file_descriptor",
@@ -98,9 +102,5 @@
       "format": "uri",
       "example": "drs://drs.example.org/314159"
     }
-  },
-  "anyOf": [
-    {"required": ["drs_uri"]},
-    {"required": ["content_type", "size",  "sha256", "crc32c"]}
-  ]
+  }
 }

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -94,6 +94,13 @@
       "user_friendly": "S3 ETag",
       "type": "string",
       "example": "c92e5374ac0a53b228d4c1511c2d2842-63"
+    },
+    "drs_uri": {
+      "description": "Data Repository Service URI",
+      "user_friendly": "DRS URI",
+      "type": "string",
+      "format": "uri",
+      "example": "drs://drs.example.org/314159"
     }
   }
 }

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -5,13 +5,13 @@
   "required": [
     "describedBy",
     "schema_type",
-    "file_id",
-    "file_version",
-    "file_name",
     "content_type",
     "size",
     "sha256",
-    "crc32c"
+    "crc32c",
+    "file_id",
+    "file_version",
+    "file_name"
   ],
   "title": "File descriptor",
   "name": "file_descriptor",

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -98,7 +98,7 @@
     "drs_uri": {
       "description": "Data Repository Service URI",
       "user_friendly": "DRS URI",
-      "type": "string",
+      "type": ["string", "null"],
       "format": "uri",
       "example": "drs://drs.example.org/314159"
     }

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -5,10 +5,6 @@
   "required": [
     "describedBy",
     "schema_type",
-    "content_type",
-    "size",
-    "sha256",
-    "crc32c",
     "file_id",
     "file_version",
     "file_name"
@@ -102,5 +98,9 @@
       "format": "uri",
       "example": "drs://drs.example.org/314159"
     }
-  }
+  },
+  "anyOf": [
+    {"required": ["drs_uri"]},
+    {"required": ["content_type", "size",  "sha256", "crc32c"]}
+  ]
 }

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -19,8 +19,7 @@
   "properties": {
     "describedBy": {
       "description": "The URL reference to the schema.",
-      "type": "string",
-      "pattern" : "^https?://schema.(.*)?humancellatlas.org/system/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/file_descriptor$"
+      "type": "string"
     },
     "schema_version": {
       "description": "The version number of the schema in major.minor.patch format.",

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -95,7 +95,7 @@
       "example": "c92e5374ac0a53b228d4c1511c2d2842-63"
     },
     "drs_uri": {
-      "description": "Data Repository Service URI",
+      "description": "Data Repository Service URI pointing at this file. If this property is absent, a data file exists in the repository containing this descriptor. If this property is present and not `null`, a data file exists in another repository at the specified URI. If this property is present but `null`, the data file is not available, but will likely become available in the future, along with an updated descriptor referencing it.",
       "user_friendly": "DRS URI",
       "type": ["string", "null"],
       "format": "uri",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+system/file_descriptor,Added,"Added optional drs_uri file to file_descriptor",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2022-03-08T10:35:01Z",
+    "last_update_date": "2022-03-21T09:39:57Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -79,7 +79,7 @@
             }
         },
         "system": {
-            "file_descriptor": "2.0.0",
+            "file_descriptor": "2.1.0",
             "license": "1.0.0",
             "links": "3.0.0",
             "provenance": "1.1.0"


### PR DESCRIPTION
### Context

The Lungmap project has a requirement to source files from an external system that will provide DRS URIs. These files will not be importable to TDR but the DRS URIs will need to be wired through into the file descriptor so they can be surfaced downstream in the browser. This is a draft PR capturing a proposal to allow the inclusion of these external DRS URIs.

[Related DCP system spec PR](https://github.com/HumanCellAtlas/dcp2/pull/55)