### PR TITLE
 Expand disease ontology to include phenotype - Fixes #1460 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,22 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [module/ontology/disease_ontology.json - v5.4.0] - 2022-05-24
+### Added
+Added the phenotype branch to graphRestrictions. Fixes #1460
+
+### [type/biomaterial/cell_line.json - v15.1.0] - 2022-05-24
+### Added
+Added the phenotype branch to graphRestrictions. Fixes #1460
+
+### [type/biomaterial/donor_organism.json - v15.6.0] - 2022-05-24
+### Added
+Added the phenotype branch to graphRestrictions. Fixes #1460
+
+### [type/biomaterial/specimen_from_organism.json - v10.5.0] - 2022-05-24
+### Added
+Added the phenotype branch to graphRestrictions. Fixes #1460
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/ontology/file_content_ontology.json - v1.1.0] - 2022-03-24

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -178,7 +178,7 @@ Location: module/ontology/disease_ontology.json
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
 text | The text for the term as the user provides it. | string | yes |  | Disease |  | type 2 diabetes mellitus; normal
-ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Disease ontology ID |  | MONDO:0005148; PATO:0000461
+ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Disease ontology ID |  | MONDO:0005148; PATO:0000461; HP:0001397
 ontology_label | The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field. | string | no |  | Disease ontology label |  | type 2 diabetes mellitus; normal
 
 ## Strain ontology<a name='Strain ontology'></a>

--- a/json_schema/module/ontology/disease_ontology.json
+++ b/json_schema/module/ontology/disease_ontology.json
@@ -37,7 +37,7 @@
                 "include_self": true
             },
             "user_friendly": "Disease ontology ID",
-            "example": "MONDO:0005148; PATO:0000461"
+            "example": "MONDO:0005148; PATO:0000461; HP:0001397"
         },
         "ontology_label": {
             "description": "The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field.",

--- a/json_schema/module/ontology/disease_ontology.json
+++ b/json_schema/module/ontology/disease_ontology.json
@@ -30,8 +30,8 @@
             "description": "An ontology term identifier in the form prefix:accession.",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:mondo", "obo:efo"],
-                "classes": ["MONDO:0000001", "PATO:0000461"],
+                "ontologies" : ["obo:mondo", "obo:efo", "obo:hp"],
+                "classes": ["MONDO:0000001", "PATO:0000461", "HP:0000118"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": true

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+module/ontology/disease_ontology,minor,"Added the phenotype branch to graphRestrictions. Fixes #1460",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-module/ontology/disease_ontology,minor,"Added the phenotype branch to graphRestrictions. Fixes #1460",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2022-03-24T08:15:15Z",
+    "last_update_date": "2022-05-24T17:06:41Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -38,7 +38,7 @@
                 "cellular_component_ontology": "1.0.5",
                 "contributor_role_ontology": "1.0.0",
                 "development_stage_ontology": "5.3.6",
-                "disease_ontology": "5.3.8",
+                "disease_ontology": "5.4.0",
                 "enrichment_ontology": "1.2.6",
                 "ethnicity_ontology": "5.3.9",
                 "file_content_ontology": "1.1.0",
@@ -86,12 +86,12 @@
         },
         "type": {
             "biomaterial": {
-                "cell_line": "15.0.0",
+                "cell_line": "15.1.0",
                 "cell_suspension": "13.3.0",
-                "donor_organism": "15.5.0",
+                "donor_organism": "15.6.0",
                 "imaged_specimen": "3.3.0",
                 "organoid": "11.3.0",
-                "specimen_from_organism": "10.4.0"
+                "specimen_from_organism": "10.5.0"
             },
             "file": {
                 "analysis_file": "6.4.0",

--- a/src/release_prepare.py
+++ b/src/release_prepare.py
@@ -104,7 +104,7 @@ class ReleasePrepare:
             log = readChangeLog.readlines()
             ignoreNextLine = False
             for line in log:
-                if "## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/develop)" in line:
+                if "## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)" in line:
                     output = output + line + "\n"
                     output = output + log_insert
                     ignoreNextLine = True


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

Schema update priority ticket with explanation on the change: https://github.com/HumanCellAtlas/metadata-schema/issues/1460

### Release notes

For module/ontology/disease_ontology schema:
- changed restrictions to include `phenotype` branch in the allowed terms.
 

### Reviews requested

- This is a minor update
- Last Reviewer to review/approve, merge changes by 27/05/2022
