### PR TITLE
Added permeabilisation time field with time units. Fixes #1471

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [type/protocol/imaging/imaging_preparation_protocol.json - v2.3.0] - 2022-08-19
+### Added
+Added permeabilisation time field with time units. Fixes #1471
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/ontology/disease_ontology.json - v5.4.0] - 2022-05-24

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -255,6 +255,8 @@ post_final_slicing_interval | Length of time between secondary slicing and hybri
 post_final_slicing_interval_unit | The unit of time in which the post final slicing interval is expressed. | object | no | [See module  time_unit_ontology](module.md/#time_unit_ontology) | Post final slicing interval time unit |  | day
 fiducial_marker | Fiducial markers for the alignment of images taken across multiple rounds of imaging. | string | no |  | Fiducial marker |  | beads
 expansion_factor | Factor by which the imaged tissue was expanded in one dimension. | number | no |  | Expansion factor |  | 3
+permeabilisation_time | The permeabilisation time in time units that the tissue was exposed to. | number | no |  | Permeabilisation time |  | 12
+permeabilisation_time_unit | The unit in which Permeabilisation time is expressed. | object | no | [See module  time_unit_ontology](module.md/#time_unit_ontology) | Permeabilisation time unit |  | 
 
 ## Imaging Protocol
 _Information about the imaging protocol._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -256,7 +256,7 @@ post_final_slicing_interval_unit | The unit of time in which the post final slic
 fiducial_marker | Fiducial markers for the alignment of images taken across multiple rounds of imaging. | string | no |  | Fiducial marker |  | beads
 expansion_factor | Factor by which the imaged tissue was expanded in one dimension. | number | no |  | Expansion factor |  | 3
 permeabilisation_time | The permeabilisation time in time units that the tissue was exposed to. | number | no |  | Permeabilisation time |  | 12
-permeabilisation_time_unit | The unit in which Permeabilisation time is expressed. | object | no | [See module  time_unit_ontology](module.md/#time_unit_ontology) | Permeabilisation time unit |  | 
+permeabilisation_time_unit | The unit in which permeabilisation time is expressed. | object | no | [See module  time_unit_ontology](module.md/#time_unit_ontology) | Permeabilisation time unit |  | 
 
 ## Imaging Protocol
 _Information about the imaging protocol._

--- a/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
+++ b/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
@@ -7,6 +7,9 @@
         "schema_type",
         "protocol_core"
     ],
+    "dependentRequired": {
+        "permeabilisation_time": ["permeabilisation_time_unit"]
+    },
     "title": "Imaging preparation protocol",
     "name": "imaging_preparation_protocol",
     "type": "object",
@@ -102,6 +105,18 @@
             "type" : "number",
             "example": "3",
             "user_friendly": "Expansion factor"
+        },
+        "permeabilisation_time": {
+            "description": "The permeabilisation time in time units that the tissue was exposed to.",
+            "type": "number",
+            "example": "12",
+            "user_friendly": "Permeabilisation time"
+        },
+        "permeabilisation_time_unit": {
+            "description": "The unit in which Permeabilisation time is expressed.",
+            "type": "object",
+            "$ref": "module/ontology/time_unit_ontology.json",
+            "user_friendly": "Permeabilisation time unit"
         }
     }
 }

--- a/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
+++ b/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
@@ -7,6 +7,10 @@
         "schema_type",
         "protocol_core"
     ],
+    "dependencies": {
+        "permeabilisation_time": ["permeabilisation_time_unit"],
+        "permeabilisation_time_unit": ["permeabilisation_time"]
+    },
     "title": "Imaging preparation protocol",
     "name": "imaging_preparation_protocol",
     "type": "object",

--- a/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
+++ b/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
@@ -7,10 +7,6 @@
         "schema_type",
         "protocol_core"
     ],
-    "dependentRequired": {
-        "permeabilisation_time": ["permeabilisation_time_unit"],
-        "permeabilisation_time_unit": ["permeabilisation_time"]
-    },
     "title": "Imaging preparation protocol",
     "name": "imaging_preparation_protocol",
     "type": "object",
@@ -114,7 +110,7 @@
             "user_friendly": "Permeabilisation time"
         },
         "permeabilisation_time_unit": {
-            "description": "The unit in which Permeabilisation time is expressed.",
+            "description": "The unit in which permeabilisation time is expressed.",
             "type": "object",
             "$ref": "module/ontology/time_unit_ontology.json",
             "user_friendly": "Permeabilisation time unit"

--- a/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
+++ b/json_schema/type/protocol/imaging/imaging_preparation_protocol.json
@@ -8,7 +8,8 @@
         "protocol_core"
     ],
     "dependentRequired": {
-        "permeabilisation_time": ["permeabilisation_time_unit"]
+        "permeabilisation_time": ["permeabilisation_time_unit"],
+        "permeabilisation_time_unit": ["permeabilisation_time"]
     },
     "title": "Imaging preparation protocol",
     "name": "imaging_preparation_protocol",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/protocol/imaging/imaging_preparation_protocol,minor,"Added permeabilisation time field with time units. Fixes #1471",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/protocol/imaging/imaging_preparation_protocol,minor,"Added permeabilisation time field with time units. Fixes #1471",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2022-05-24T17:06:41Z",
+    "last_update_date": "2022-08-19T14:15:58Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -122,7 +122,7 @@
                     "ipsc_induction_protocol": "3.2.0"
                 },
                 "imaging": {
-                    "imaging_preparation_protocol": "2.2.0",
+                    "imaging_preparation_protocol": "2.3.0",
                     "imaging_protocol": "11.4.0"
                 },
                 "protocol": "7.1.0",


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

For `type/protocol/imaging/imaging_preparation_protocol.json` schema:
- Added non-required field `permeabilisation_time`
- Added non-required field `permeabilisation_time_unit`
- Added dependency between permeabilisation_time and permeabilisation_time_unit
 

### Reviews requested

- This is a minor update
- Reviews are requested as per usual


### Rationale
Based on the findings by the education team, exposed in the [May 24th demos](https://docs.google.com/presentation/d/10-Ei7SXCqyrLLlWyAGWxS0E02bG6r-sIAumyHBtDoIo/edit#slide=id.g12e39c13645_1_0), we have decided to add the "permeabilisation time" field to the imaging_preparation_protocol to ensure we are capturing the information needed to represent Visium experiments


see #1471