### PR TITLE
[HOTFIX] remove linting as failure condition for a PR

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,9 +12,6 @@ overrides:
 - if: "'on hold' in labels"
   status: pending
   explanation: "PR review is on hold"
-- if: "'linting' not in check_runs.success"
-  status: failure
-  explanation: "Schema must be Linted before review starts"
 - if:  "'tests' not in check_runs.success"
   status: failure
   explanation: "Schema must pass Tests before review starts"


### PR DESCRIPTION
Linting is now done with GitHub Actions, so the linting status is automatically diplayed when the PR is opened.

This change allows to do both at the same time:
- do the linting
- pullapprove can request reviews on the PR

