### PR TITLE
[Hotfix] Fixed target_pathway_ontology and treatment_method_ontology

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -126,7 +126,7 @@ text | The name of the treatment target pathway. | string | yes |  | Target path
 ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Target pathway ontology ID |  | GO:0043382
 ontology_label | The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field. | string | no |  | Target pathway ontology label |  | positive regulation of memory T cell differentiation
 
-## Treatment ontology<a name='Treatment ontology'></a>
+## Treatment method ontology<a name='Treatment method ontology'></a>
 _A term that may be associated with a process-related ontology term._
 
 Location: module/ontology/treatment_method_ontology.json

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -126,8 +126,8 @@ method | Method applied to cell culture to induce a specific differentiation res
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | protocol | 
-protocol_core | Core protocol-level information. | object | [See core  protocol_core](core.md/#protocol_core) | Protocol core |  | 
-method | Method applied to cell culture to induce a specific treatment response. | array | [See module  treatment_method_ontology](module.md/#treatment_method_ontology) | Treatment method |  | 
+protocol_core | Core protocol-level information. | object | [See core  protocol_core](core.md#protocol-core) | Protocol core |  | 
+method | Method applied to cell culture to induce a specific treatment response. | array | [See module  treatment_method_ontology](module.md#treatment-method-ontology) | Treatment method |  | 
 ### Imaging preparation protocol
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
@@ -246,7 +246,7 @@ text | The ethnicity of the human donor. | string |  | Ethnicity |  | European; 
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
 text | The name of the treatment target pathway. | string |  | Target pathway |  | positive regulation of memory T cell differentiation
-### Treatment ontology<a name='Treatment ontology'></a>
+### Treatment method ontology<a name='Treatment method ontology'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
 text | The name of a treatment method or approach being used. | string |  | Treatment method |  | T cell activation assay

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -243,12 +243,12 @@ Location: type/protocol/biomaterial_collection/treatment_protocol.json
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string | yes |  |  | protocol | 
-provenance | Provenance information provided by the system. | object | no | [See   provenance](.md/#provenance) |  |  | 
-protocol_core | Core protocol-level information. | object | yes | [See core  protocol_core](core.md/#protocol_core) | Protocol core |  | 
-method | Method applied to cell culture to induce a specific treatment response. | array | yes | [See module  treatment_method_ontology](module.md/#treatment_method_ontology) | Treatment method |  | 
+provenance | Provenance information provided by the system. | object | no | [See   provenance](.md#provenance) |  |  | 
+protocol_core | Core protocol-level information. | object | yes | [See core  protocol_core](core.md#protocol-core) | Protocol core |  | 
+method | Method applied to cell culture to induce a specific treatment response. | array | yes | [See module  treatment_method_ontology](module.md#treatment-method-ontology) | Treatment method |  | 
 media | Culture media used to induce a specific treatment response. | string | no |  | Treatment media |  | RPMI 1640; Complete Medium
-reagents | A list of purchased reagents used in the treatment protocol. | array | no | [See module  purchased_reagents](module.md/#purchased_reagents) | Treatment reagents |  | 
-target_pathway | Targeted pathway for specific treatment response. | array | no | [See module  target_pathway_ontology](module.md/#target_pathway_ontology) | Target pathway |  | insulin signalling pathway; immune cell activation; chemokine signalling pathway.
+reagents | A list of purchased reagents used in the treatment protocol. | array | no | [See module  purchased_reagents](module.md#purchased-reagents) | Treatment reagents |  | 
+target_pathway | Targeted pathway for specific treatment response. | array | no | [See module  target_pathway_ontology](module.md#target-pathway-ontology) | Target pathway |  | insulin signalling pathway; immune cell activation; chemokine signalling pathway.
 
 ## Imaging preparation protocol
 _Information about the preparation protocol of the imaged specimen used in an imaging experiment._

--- a/json_schema/module/ontology/target_pathway_ontology.json
+++ b/json_schema/module/ontology/target_pathway_ontology.json
@@ -30,7 +30,7 @@
             "description": "An ontology term identifier in the form prefix:accession.",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:go"],
+                "ontologies" : ["obo:hcao"],
                 "classes": ["GO:0050789"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,

--- a/json_schema/module/ontology/treatment_method_ontology.json
+++ b/json_schema/module/ontology/treatment_method_ontology.json
@@ -5,8 +5,8 @@
     "required": [
         "text"
     ],
-    "title": "Treatment ontology",
-    "name": "treatment_ontology",
+    "title": "Treatment method ontology",
+    "name": "treatment_method_ontology",
     "type": "object",
     "properties": {
         "describedBy":  {


### PR DESCRIPTION
Fixed the recently added schemas:
- `module/ontologies/treatment_method_ontology`: Changed `title` and `name` properties to match with schema name, according to our style guidelines
- `module/ontologies/target_pathway_ontology`: changed the `graph_restrictions` to point to `hcao` rather than `go`