### PR TITLE
Added value 'DCP/2 Ingest' to enum for file source. Fixes #1487.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,30 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [core/file/file_core.json - v6.4.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
+### [type/file/supplementary_file.json - v2.5.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
+### [type/file/image_file.json - v2.5.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
+### [type/file/sequence_file.json - v9.5.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
+### [type/file/analysis_file.json - v6.5.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
+### [type/file/reference_file.json - v3.5.0] - 2022-09-16
+### Added
+Added value to enum for file source. Fixes #1487.
+
 ### [system/links.json - v3.1.0] - 2022-09-16
 ### Added
 Added treatment protocol to protocol_type. Fixes #1488.

--- a/docs/jsonBrowser/core.md
+++ b/docs/jsonBrowser/core.md
@@ -18,7 +18,7 @@ file_name | The name of the file. | string | yes |  | File name |  | R1.fastq.gz
 format | The format of the file. | string | yes |  | File format |  | fastq.gz; tif
 content_description | General description of the contents of the file. | array | no | [See module  file_content_ontology](module.md#file-content-ontology) | Content description |  | 
 checksum | MD5 checksum of the file. | string | no |  | Checksum |  | e09a986c2e630130b1849d4bf9a94c06
-file_source | The source of the file. This is typically an organisation, repository, person or dedicated process. | string | no |  | File source | DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication, HCA Ingest | GEO; Contributor
+file_source | The source of the file. This is typically an organisation, repository, person or dedicated process. | string | no |  | File source | DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication, DCP/2 Ingest | GEO; Contributor
 
 ## Protocol core<a name='Protocol core'></a>
 _Information about an intended protocol that was followed in the project._

--- a/docs/jsonBrowser/core.md
+++ b/docs/jsonBrowser/core.md
@@ -18,7 +18,7 @@ file_name | The name of the file. | string | yes |  | File name |  | R1.fastq.gz
 format | The format of the file. | string | yes |  | File format |  | fastq.gz; tif
 content_description | General description of the contents of the file. | array | no | [See module  file_content_ontology](module.md#file-content-ontology) | Content description |  | 
 checksum | MD5 checksum of the file. | string | no |  | Checksum |  | e09a986c2e630130b1849d4bf9a94c06
-file_source | The source of the file. This is typically an organisation, repository, person or dedicated process. | string | no |  | File source | DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication | GEO; Contributor
+file_source | The source of the file. This is typically an organisation, repository, person or dedicated process. | string | no |  | File source | DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication, HCA Ingest | GEO; Contributor
 
 ## Protocol core<a name='Protocol core'></a>
 _Information about an intended protocol that was followed in the project._

--- a/json_schema/core/file/file_core.json
+++ b/json_schema/core/file/file_core.json
@@ -65,7 +65,7 @@
                 "LungMAP",
                 "Zenodo",
                 "Publication",
-                "HCA Ingest"
+                "DCP/2 Ingest"
             ],
             "user_friendly": "File source",
             "guidelines": "Should be one of: DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication",

--- a/json_schema/core/file/file_core.json
+++ b/json_schema/core/file/file_core.json
@@ -68,7 +68,7 @@
                 "DCP/2 Ingest"
             ],
             "user_friendly": "File source",
-            "guidelines": "Should be one of: DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication",
+            "guidelines": "Should be one of: DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication, DCP/2 Ingest",
             "example": "GEO; Contributor"
             }
     }

--- a/json_schema/core/file/file_core.json
+++ b/json_schema/core/file/file_core.json
@@ -64,7 +64,8 @@
                 "DCP/1 Matrix Service",
                 "LungMAP",
                 "Zenodo",
-                "Publication"
+                "Publication",
+                "HCA Ingest"
             ],
             "user_friendly": "File source",
             "guidelines": "Should be one of: DCP/2 Analysis, Contributor, ArrayExpress, HCA Release, GEO, SCEA, SCP, DCP/1 Matrix Service, LungMAP, Zenodo, Publication",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+core/file/file_core,minor,"Added value to enum for file source. Fixes #1487.",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-core/file/file_core,minor,"Added value to enum for file source. Fixes #1487.",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,12 +1,12 @@
 {
-    "last_update_date": "2022-09-16T09:17:43Z",
+    "last_update_date": "2022-09-16T11:56:05Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
                 "biomaterial_core": "8.2.0"
             },
             "file": {
-                "file_core": "6.3.0"
+                "file_core": "6.4.0"
             },
             "process": {
                 "process_core": "10.0.0"
@@ -96,11 +96,11 @@
                 "specimen_from_organism": "10.5.0"
             },
             "file": {
-                "analysis_file": "6.4.0",
-                "image_file": "2.4.0",
-                "reference_file": "3.4.0",
-                "sequence_file": "9.4.0",
-                "supplementary_file": "2.4.0"
+                "analysis_file": "6.5.0",
+                "image_file": "2.5.0",
+                "reference_file": "3.5.0",
+                "sequence_file": "9.5.0",
+                "supplementary_file": "2.5.0"
             },
             "process": {
                 "analysis": {


### PR DESCRIPTION
### Release notes

For `file_core` schema:
- Added value to enum for file source
 

### Reviews requested

- This is a minor change to all the schemas it affects (file_core + file type schemas)
