### PR TITLE
Added genome assembly and patch versions. Fixes #1508.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [type/file/analysis_file.json - v7.0.0] - 2023-01-30
+### Added
+Added genome assembly and patch version. Fixes #1508.
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/protocol/matrix.json - v2.0.0] - 2022-10-31

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -47,6 +47,7 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 schema_type | The type of the metadata schema entity. | string |  |  | file | 
 file_core | Core file-level information. | object | [See core  file_core](core.md#file-core) | File core |  | 
+genome_assembly_version | Name of the genome assembly used to generate this file. | string |  | Genome version | GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable | Should be one of: GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable
 ### Reference file
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -57,6 +57,8 @@ schema_type | The type of the metadata schema entity. | string | yes |  |  | fil
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md#file-core) | File core |  | 
 matrix_cell_count | Number of cells analyzed in a matrix file. | integer | no |  | Matrix cell count |  | 1; 2100
+genome_assembly_version | Name of the genome assembly used to generate this file. | string | no |  | Genome version | GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable | Should be one of: GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable
+genome_patch_version | Patch version of the genome assembly used to generate this file. | string | no |  | Patch version |  | p11; p14
 
 ## Reference file
 _A reference file used by a secondary reference pipeline._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -57,7 +57,7 @@ schema_type | The type of the metadata schema entity. | string | yes |  |  | fil
 provenance | Provenance information provided by the system. | object | no | [See   provenance](.md#provenance) |  |  | 
 file_core | Core file-level information. | object | yes | [See core  file_core](core.md#file-core) | File core |  | 
 matrix_cell_count | Number of cells analyzed in a matrix file. | integer | no |  | Matrix cell count |  | 1; 2100
-genome_assembly_version | Name of the genome assembly used to generate this file. | string | no |  | Genome version | GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable | Should be one of: GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable
+genome_assembly_version | Name of the genome assembly used to generate this file. | string | yes |  | Genome version | GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable | Should be one of: GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable
 genome_patch_version | Patch version of the genome assembly used to generate this file. | string | no |  | Patch version |  | p11; p14
 
 ## Reference file

--- a/json_schema/property_migrations.json
+++ b/json_schema/property_migrations.json
@@ -1,6 +1,13 @@
 {
     "migrations": [
         {
+            "source_schema": "analysis_file",
+            "property": "genome_assembly_version",
+            "effective_from": "7.0.0",
+            "reason": "Genome assembly is now recorded as a mandatory field",
+            "type": "new required property"
+        },
+        {
             "source_schema": "file_descriptor",
             "property": "schema_major_version",
             "effective_from": "2.0.0",

--- a/json_schema/type/file/analysis_file.json
+++ b/json_schema/type/file/analysis_file.json
@@ -5,7 +5,8 @@
     "required": [
         "describedBy",
         "schema_type",
-        "file_core"
+        "file_core",
+        "genome_version"
     ],
     "title": "Analysis file",
     "name": "analysis_file",
@@ -48,6 +49,27 @@
             "example": "1; 2100",
             "user_friendly": "Matrix cell count",
             "guidelines": "If the analysis file is a matrix containing cells, enter the exact number of cells in the matrix."
+        },
+        "genome_assembly_version": {
+            "description": "Name of the genome assembly used to generate this file.",
+            "type": "string",
+            "user_friendly": "Genome version",
+            "enum": [
+                "GRCh38",
+                "GRCh37",
+                "GRCm39",
+                "GRCm38",
+                "GRCm37",
+                "Not Applicable"
+            ],
+            "guidelines": "Please use the name as defined in the Genome Reference Consortium (https://www.ncbi.nlm.nih.gov/grc)",
+            "example": "Should be one of: GRCh38, GRCh37, GRCm39, GRCm38, GRCm37, Not Applicable"
+        },
+        "genome_patch_version": {
+            "description": "Patch version of the genome assembly used to generate this file.",
+            "type": "string",
+            "user_friendly": "Patch version",
+            "example": "p11; p14"
         }
     }
 }

--- a/json_schema/type/file/analysis_file.json
+++ b/json_schema/type/file/analysis_file.json
@@ -6,7 +6,7 @@
         "describedBy",
         "schema_type",
         "file_core",
-        "genome_version"
+        "genome_assembly_version"
     ],
     "title": "Analysis file",
     "name": "analysis_file",

--- a/json_schema/type/file/analysis_file.json
+++ b/json_schema/type/file/analysis_file.json
@@ -8,6 +8,9 @@
         "file_core",
         "genome_assembly_version"
     ],
+    "dependencies": {
+        "genome_patch_version": ["genome_assembly_version"]
+    },
     "title": "Analysis file",
     "name": "analysis_file",
     "type": "object",

--- a/json_schema/type/file/analysis_file.json
+++ b/json_schema/type/file/analysis_file.json
@@ -8,9 +8,6 @@
         "file_core",
         "genome_assembly_version"
     ],
-    "dependencies": {
-        "genome_patch_version": ["genome_assembly_version"]
-    },
     "title": "Analysis file",
     "name": "analysis_file",
     "type": "object",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/file/analysis_file,major,"Added genome assembly and patch version. Fixes #1508.",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/file/analysis_file,major,"Added genome assembly and patch version. Fixes #1508.",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2022-10-31T11:11:44Z",
+    "last_update_date": "2023-01-30T10:25:12Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -96,7 +96,7 @@
                 "specimen_from_organism": "10.5.0"
             },
             "file": {
-                "analysis_file": "6.5.0",
+                "analysis_file": "7.0.0",
                 "image_file": "2.5.0",
                 "reference_file": "3.5.0",
                 "sequence_file": "9.5.0",


### PR DESCRIPTION
### Release notes

For `type/file/analysis.json` schema:
- Added `genome_assembly_version` required field
- Added `genome_patch_version` field
 
### Why are these changes needed?

This change is needed for data consumers, as part of the metadata needed to correct for batch effects and harmonise the data to build proper cell atlases


### Reviews requested

- This is a major update, so it requires the review of all the DCP/2 approved PR reviewers
