### PR TITLE
Added HCA Tissue Atlas, HCA Tissue Atlas Version, Project Integrated Status, and HCA Project uuid field. Fixes #1517

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -388,6 +388,9 @@ doi | The publication digital object identifier (doi) of the publication. | stri
 pmid | The PubMed ID of the publication. | integer | no |  | Publication PMID |  | 27565351
 url | A URL for the publication. | string | no |  | Publication URL |  | https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/
 official_hca_publication | Has the publication been accepted as an official HCA publication, according to the process described in https://www.humancellatlas.org/publications/ ? | boolean | yes |  | Official HCA Publication |  | yes; no
+hca_tissue_atlas | A field describing if the project is part of an HCA Tissue Atlas (e.g. Kidney). Enter ‘No’ if the project is not part of an HCA Tissue Atlas. | string | no |  | Official HCA Tissue Atlas | Adipose, Breast, Blood, Development, Eye, Genetic Diversity, Gut, Heart, Immune, Kidney, Liver, Lung, Musculoskeletal, Nervous System, Oral & Craniofacial, Organoid, Pancrease, Reproduction, Skin, No | Kidney; Lung; No
+integrated_status | A field describing if the HCA Tissue Atlas project integrates data from other projects.  | string | no |  | Project Integrated Status | Atlas Project, No | Atlas Project; No
+hca_tissue_atlas_version | A field describing which version of the HCA Tissue Atlas is associated with the publication (e.g. v1.0; v2.0) | string | no |  | Official HCA Tissue Atlas Version |  | v1.0; v2.0
 
 ## Human-specific<a name='Human-specific'></a>
 _Information specific to a donor that is a human (Homo sapiens)._

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -388,9 +388,10 @@ doi | The publication digital object identifier (doi) of the publication. | stri
 pmid | The PubMed ID of the publication. | integer | no |  | Publication PMID |  | 27565351
 url | A URL for the publication. | string | no |  | Publication URL |  | https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/
 official_hca_publication | Has the publication been accepted as an official HCA publication, according to the process described in https://www.humancellatlas.org/publications/ ? | boolean | yes |  | Official HCA Publication |  | yes; no
-hca_tissue_atlas | A field describing if the project is part of an HCA Tissue Atlas (e.g. Kidney). Enter ‘No’ if the project is not part of an HCA Tissue Atlas. | string | no |  | Official HCA Tissue Atlas | Adipose, Breast, Blood, Development, Eye, Genetic Diversity, Gut, Heart, Immune, Kidney, Liver, Lung, Musculoskeletal, Nervous System, Oral & Craniofacial, Organoid, Pancrease, Reproduction, Skin, No | Kidney; Lung; No
-integrated_status | A field describing if the HCA Tissue Atlas project integrates data from other projects.  | string | no |  | Project Integrated Status | Atlas Project, No | Atlas Project; No
+hca_tissue_atlas | A field describing if the project is part of an official HCA Tissue Atlas (e.g. Kidney). Enter ‘No’ if the project is not part of an official HCA Tissue Atlas. | string | no |  | Official HCA Tissue Atlas | Adipose, Breast, Blood, Development, Eye, Genetic Diversity, Gut, Heart, Immune, Kidney, Liver, Lung, Musculoskeletal, Nervous System, Oral & Craniofacial, Organoid, Pancreas, Reproduction, Skin, No | Kidney; Lung; No
+integrated_status | A field describing if the HCA Tissue Atlas project is the result of dataset integration.  | string | no |  | Project Integrated Status | Atlas Project, No | Atlas Project; No
 hca_tissue_atlas_version | A field describing which version of the HCA Tissue Atlas is associated with the publication (e.g. v1.0; v2.0) | string | no |  | Official HCA Tissue Atlas Version |  | v1.0; v2.0
+hca_project_uuid | A field describing the uuid of the HCA Project that is associated with the publication (e.g. b963bd4b-4bc1-4404-8425-69d74bc636b8) | string | no |  | HCA Project UUID |  | b963bd4b-4bc1-4404-8425-69d74bc636b8
 
 ## Human-specific<a name='Human-specific'></a>
 _Information specific to a donor that is a human (Homo sapiens)._

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -103,7 +103,7 @@
         "hca_tissue_atlas_version": {
             "description": "A field describing which version of the HCA Tissue Atlas is associated with the publication (e.g. v1.0; v2.0)",
             "type": "string",
-            "pattern": "v[0-9].[0-9]",
+            "pattern": "^v[0-9]+\\.[0-9]+$",
             "user_friendly": "Official HCA Tissue Atlas Version",
             "guidelines": "For example: v1.0; v2.0",
             "example": "v1.0; v2.0"

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -62,6 +62,50 @@
             "user_friendly": "Official HCA Publication",
             "guidelines": "Should be one of: yes, or no.",
             "example": "yes; no"
+        },
+        "hca_tissue_atlas": {
+            "description": "A field describing if the project is part of an HCA Tissue Atlas (e.g. Kidney). Enter ‘No’ if the project is not part of an HCA Tissue Atlas.",
+            "type": "string",
+            "enum": [
+                "Adipose",
+                "Breast",
+                "Blood",
+                "Development",
+                "Eye",
+                "Genetic Diversity",
+                "Gut",
+                "Heart",
+                "Immune",
+                "Kidney",
+                "Liver",
+                "Lung",
+                "Musculoskeletal",
+                "Nervous System",
+                "Oral & Craniofacial",
+                "Organoid",
+                "Pancrease",
+                "Reproduction",
+                "Skin",
+                "No"
+            ],
+            "user_friendly": "Official HCA Tissue Atlas",
+            "guidelines": "Should be one of the networks from https://www.humancellatlas.org/biological-networks/ or 'No' if not a network",
+            "example": "Kidney; Lung; No"
+        },
+        "integrated_status": {
+            "description": "A field describing if the HCA Tissue Atlas project integrates data from other projects. ",
+            "type": "string",
+            "enum": ["Atlas Project","No"],
+            "user_friendly": "Project Integrated Status",
+            "guidelines": "Enter ‘Atlas Project’ if this project is one of the HCA Tissue Atlases and it integrates data from all other datasets. Enter ‘No’, if this project's data is being integrated.",
+            "example": "Atlas Project; No"
+        },
+        "hca_tissue_atlas_version": {
+            "description": "A field describing which version of the HCA Tissue Atlas is associated with the publication (e.g. v1.0; v2.0)",
+            "type": "string",
+            "user_friendly": "Official HCA Tissue Atlas Version",
+            "guidelines": "For example: v1.0; v2.0",
+            "example": "v1.0; v2.0"
         }
     }
 }

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -107,6 +107,14 @@
             "user_friendly": "Official HCA Tissue Atlas Version",
             "guidelines": "For example: v1.0; v2.0",
             "example": "v1.0; v2.0"
+        },
+        "hca_project_uuid": {
+            "description": "A field describing the uuid of the HCA Project that is associated with the publication (e.g. b963bd4b-4bc1-4404-8425-69d74bc636b8)",
+            "type": "string",
+            "pattern": "([0-9a-z]){8}-([0-9a-z]){4}-([0-9a-z]){4}-([0-9a-z]){4}-([0-9a-z]){12}",
+            "user_friendly": "HCA Project UUID",
+            "guidelines": "For example: b963bd4b-4bc1-4404-8425-69d74bc636b8",
+            "example": "b963bd4b-4bc1-4404-8425-69d74bc636b8"
         }
     }
 }

--- a/json_schema/module/project/publication.json
+++ b/json_schema/module/project/publication.json
@@ -103,6 +103,7 @@
         "hca_tissue_atlas_version": {
             "description": "A field describing which version of the HCA Tissue Atlas is associated with the publication (e.g. v1.0; v2.0)",
             "type": "string",
+            "pattern": "v[0-9].[0-9]",
             "user_friendly": "Official HCA Tissue Atlas Version",
             "guidelines": "For example: v1.0; v2.0",
             "example": "v1.0; v2.0"

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,2 @@
 Schema,Change type,Change message,Version,Date
-module/publication,minor,Added three metadata schema fields to module/publication for HCA Tissue Atlas Grouping. Fixes #1517,,
+module/publication,minor,Added four metadata schema fields to module/publication for HCA Tissue Atlas Grouping. Fixes #1517,,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+module/publication,minor,Added three metadata schema fields to module/publication for HCA Tissue Atlas Grouping. Fixes #1517,,


### PR DESCRIPTION
<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

For module/project/publication.json schema:
- Added `hca_tissue_atlas` field
- Added `integrated_status` field
- Added `hca_tissue_atlas_version` field
- Added `hca_project_uuid` field
 
### Why are these changes needed?

This change is needed for data contributors and consumers, to identify projects part of an official HCA Tissue Atlas, to identify the Atlas Project which integrates other analysis files, denote the version of the HCA Tissue Atlas, and describe the uuid of the associated HCA Project 

### Reviews requested

- Need Reviewers to approve because this is a minor update

We have planned the four metadata schema fields to explicitly describe the metadata of the project. [Wrangler meeting notes](https://docs.google.com/document/d/1N3dJA5dQuJcY5pxhT2pNgwZptKfdH3BSsqZSnWD0nUo/edit#)
[Example spreadsheet](https://docs.google.com/spreadsheets/d/1CiyCJZ96lu3PBLr7RAgbz08h1qA66n0Z/edit?usp=sharing&ouid=114069941208994528669&rtpof=true&sd=true)