### PR TITLE
Added hca_bionetwork module to Project. Fixes #1517 

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -357,6 +357,18 @@ grant_title | The name of the grant funding the project. | string | no |  | Gran
 grant_id | The unique grant identifier or reference. | string | yes |  | Grant ID |  | BB/P0000001/1
 organization | The name of the funding organization. | string | yes |  | Funding organization |  | Biotechnology and Biological Sciences Research Council (BBSRC); California Institute of Regenerative Medicine (CIRM)
 
+## HCA Bionetwork<a name='HCA Bionetwork'></a>
+_Information about whether the project is part of a HCA Bionetwork or HCA Atlas._
+
+Location: module/project/hca_bionetwork.json
+
+Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- | --- 
+Names | A field describing which HCA Bionetwork the project is a part of (e.g. Kidney). Enter ‘No’ if the project is not part of an official HCA Bionetwork. | string | no |  | Official HCA Bionetwork(s) | Adipose, Breast, Blood, Development, Eye, Genetic Diversity, Gut, Heart, Immune, Kidney, Liver, Lung, Musculoskeletal, Nervous System, Oral & Craniofacial, Organoid, Pancreas, Reproduction, Skin, No | Kidney; Lung; No
+hca_tissue_atlas | A field describing if the project is part of a HCA Tissue Atlas (e.g. Brain Alzheimer Atlas).  | string | no |  | HCA Tissue Atlas |  | Brain Alzheimer Atlas
+hca_tissue_atlas_version | A field describing which version of the HCA Tissue Atlas is associated with the projet (e.g. v1.0; v2.0) | string | no |  | Official HCA Tissue Atlas Version |  | v1.0; v2.0
+atlas_project | A field describing if this project is the HCA Tissue Atlas project which integrates data from other datasets. | string | no |  | Project Tissue Atlas Status | Yes, No | Atlas Project; No
+
 ## Contact<a name='Contact'></a>
 _Information about an individual who submitted or contributed to a project._
 

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -332,6 +332,9 @@ Property name | Description | Type | Object reference? | User friendly name | Al
 --- | --- | --- | --- | --- | --- | --- 
 grant_id | The unique grant identifier or reference. | string |  | Grant ID |  | BB/P0000001/1
 organization | The name of the funding organization. | string |  | Funding organization |  | Biotechnology and Biological Sciences Research Council (BBSRC); California Institute of Regenerative Medicine (CIRM)
+### HCA Bionetwork<a name='HCA Bionetwork'></a>
+Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- 
 ### Contact<a name='Contact'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -314,7 +314,7 @@ project_core | Core project-level information. | object | yes | [See core  proje
 contributors | People contributing to any aspect of the project. | array | no | [See module  contact](module.md#contact) | Contributors |  | 
 supplementary_links | External link(s) pointing to code, supplementary data files, or analysis files associated with the project which will not be uploaded. | array | no |  | Supplementary link(s) |  | https://github.com/czbiohub/tabula-muris; http://celltag.org/
 publications | Publications resulting from this project. | array | no | [See module  publication](module.md#publication) | Publications |  | 
-hca_bionetwork | HCA Bionetworks and Atlases the project is associated with | array | no | [See module  hca_bionetwork](module.md#hca-bionetwork) | Publications |  | 
+hca_bionetwork | HCA Bionetworks and Atlases the project is associated with | array | no | [See module  hca_bionetwork](module.md#hca-bionetwork) | HCA Bionetwork |  | 
 insdc_project_accessions | An International Nucleotide Sequence Database Collaboration (INSDC) project accession. | array | no |  | INSDC project accession |  | SRP000000
 ega_accessions | A list of accessions referring to EGA (European Genome-Phenome Archive) datasets or studies. | array | no |  | EGA Study/Dataset Accession(s) |  | EGAS00000000001; EGAD00000000002
 dbgap_accessions | A list of database of Genotypes and Phenotypes (dbGaP) study accessions. | array | no |  | dbGaP Study Accession(s) |  | phs001997.v1.p1; phs001836

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -314,6 +314,7 @@ project_core | Core project-level information. | object | yes | [See core  proje
 contributors | People contributing to any aspect of the project. | array | no | [See module  contact](module.md#contact) | Contributors |  | 
 supplementary_links | External link(s) pointing to code, supplementary data files, or analysis files associated with the project which will not be uploaded. | array | no |  | Supplementary link(s) |  | https://github.com/czbiohub/tabula-muris; http://celltag.org/
 publications | Publications resulting from this project. | array | no | [See module  publication](module.md#publication) | Publications |  | 
+hca_bionetwork | HCA Bionetworks and Atlases the project is associated with | array | no | [See module  hca_bionetwork](module.md#hca-bionetwork) | Publications |  | 
 insdc_project_accessions | An International Nucleotide Sequence Database Collaboration (INSDC) project accession. | array | no |  | INSDC project accession |  | SRP000000
 ega_accessions | A list of accessions referring to EGA (European Genome-Phenome Archive) datasets or studies. | array | no |  | EGA Study/Dataset Accession(s) |  | EGAS00000000001; EGAD00000000002
 dbgap_accessions | A list of database of Genotypes and Phenotypes (dbGaP) study accessions. | array | no |  | dbGaP Study Accession(s) |  | phs001997.v1.p1; phs001836

--- a/json_schema/module/project/hca_bionetwork.json
+++ b/json_schema/module/project/hca_bionetwork.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Information about whether the project is part of a HCA Bionetwork or HCA Atlas.",
+    "additionalProperties": false,
+    "required": [
+    ],
+    "title": "HCA Bionetwork",
+    "name": "hca_bionetwork",
+    "type": "object",
+    "properties": {
+        "describedBy": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/contact"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "Names": {
+            "description": "A field describing which HCA Bionetwork the project is a part of (e.g. Kidney). Enter ‘No’ if the project is not part of an official HCA Bionetwork.",
+        	"type": "string",
+            "enum": [
+                "Adipose",
+                "Breast",
+                "Blood",
+                "Development",
+                "Eye",
+                "Genetic Diversity",
+                "Gut",
+                "Heart",
+                "Immune",
+                "Kidney",
+                "Liver",
+                "Lung",
+                "Musculoskeletal",
+                "Nervous System",
+                "Oral & Craniofacial",
+                "Organoid",
+                "Pancreas",
+                "Reproduction",
+                "Skin",
+                "No"
+            ],
+            "user_friendly": "Official HCA Bionetwork(s)",
+            "guidelines": "Should be one of the networks from https://www.humancellatlas.org/biological-networks/ or 'No' if not a network",
+            "example": "Kidney; Lung; No"
+        },
+        "hca_tissue_atlas": {
+            "description": "A field describing if the project is part of a HCA Tissue Atlas (e.g. Brain Alzheimer Atlas). ",
+            "type": "string",
+            "user_friendly": "HCA Tissue Atlas",
+            "guidelines": "For example: Brain Alzheimer Atlas",
+            "example": "Brain Alzheimer Atlas"
+	},
+        "hca_tissue_atlas_version": {
+            "description": "A field describing which version of the HCA Tissue Atlas is associated with the projet (e.g. v1.0; v2.0)",
+            "type": "string",
+            "pattern": "v[0-9].[0-9]",
+            "user_friendly": "Official HCA Tissue Atlas Version",
+            "guidelines": "For example: v1.0; v2.0",
+            "example": "v1.0; v2.0"
+        },
+        "atlas_project": {
+            "description": "A field describing if this project is the HCA Tissue Atlas project which integrates data from other datasets.",
+            "type": "string",
+            "enum": ["Yes","No"],
+            "user_friendly": "Project Tissue Atlas Status",
+            "guidelines": "Enter ‘Yes’ if this project is one of the HCA Tissue Atlases and it integrates data from all other datasets. Enter ‘No’, if this project's data is being integrated.",
+            "example": "Atlas Project; No"
+        }
+    }
+}

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -72,7 +72,7 @@
             "items": {
                 "$ref": "module/project/hca_bionetwork.json"
             },
-            "user_friendly": "Publications"
+            "user_friendly": "HCA Bionetwork"
         },
         "insdc_project_accessions": {
             "description": "An International Nucleotide Sequence Database Collaboration (INSDC) project accession.",

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -66,6 +66,14 @@
             },
             "user_friendly": "Publications"
         },
+        "hca_bionetwork": {
+            "description": "HCA Bionetworks and Atlases the project is associated with",
+            "type": "array",
+            "items": {
+                "$ref": "module/project/hca_bionetwork.json"
+            },
+            "user_friendly": "Publications"
+        },
         "insdc_project_accessions": {
             "description": "An International Nucleotide Sequence Database Collaboration (INSDC) project accession.",
             "type": "array",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,3 @@
 Schema,Change type,Change message,Version,Date
+module/project/hca_bionetwork,minor,"Added the hca_bionetwork module with four fields for recording bionetwork and atlas information",,
+type/project/project,minor,"Added the hca_bionetwork module to be loaded in project",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -72,7 +72,8 @@
             "project": {
                 "contact": "9.0.0",
                 "funder": "2.0.0",
-                "publication": "7.0.0"
+                "publication": "7.0.0",
+                "hca_bionetwork": "0.0.0"
             },
             "protocol": {
                 "channel": "2.0.4",


### PR DESCRIPTION
<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes
Added module/project/hca_bionetwork.json schema:
- Added `names` field
- Added `hca_tissue_atlas` field
- Added `hca_tissue_atlas_version` field
- added `atlas_project` field

### Why are these changes needed?

This change is needed for data contributors and consumers, to describe if this project is part of a HCA bionetwork, is part of a HCA Atlas, what version of the atlas, and whether it is the 'Atlas Project' containing a h5ad file that draws from other projects or not. 

### Reviews requested

- Need Reviewers to approve because this is a minor update

Discussion here: https://miro.com/app/board/uXjVMfMlgLc=/
We have planned the four metadata schema fields to explicitly describe the metadata of the project. [Wrangler meeting notes](https://docs.google.com/document/d/1N3dJA5dQuJcY5pxhT2pNgwZptKfdH3BSsqZSnWD0nUo/edit#)
[Example spreadsheet](https://docs.google.com/spreadsheets/d/1CiyCJZ96lu3PBLr7RAgbz08h1qA66n0Z/edit?usp=sharing&ouid=114069941208994528669&rtpof=true&sd=true)