### PR TITLE
dcp-954 fix hca_bionetwork schema url

### DIFF
--- a/json_schema/module/project/hca_bionetwork.json
+++ b/json_schema/module/project/hca_bionetwork.json
@@ -9,7 +9,7 @@
         "describedBy": {
             "description": "The URL reference to the schema.",
             "type": "string",
-            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/contact"
+            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/hca_bionetwork"
         },
         "schema_version": {
             "description": "The version number of the schema in major.minor.patch format.",


### PR DESCRIPTION
schema url (`describedBy`) pattern was incorrect.

ebi-ait/dcp-ingest-central#954
Fixes: #1527
Related to: #1517