### PR TITLE
Removed timecourse from types and added to biomaterial core. Fixes #1511

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,34 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [core/biomaterial/biomaterial_core.json - v8.4.0] - 2023-08-22
+### Added
+Added timecourse module. Fixes #1511
+
+### [type/biomaterial/donor_organism.json - v16.0.0] - 2023-08-22
+### Removed
+Removed timecourse module.
+
+### [type/biomaterial/cell_suspension.json - v14.0.0] - 2023-08-22
+### Removed
+Removed timecourse module.
+
+### [type/biomaterial/cell_line.json - v16.0.0] - 2023-08-22
+### Removed
+Removed timecourse module.
+
+### [type/biomaterial/imaged_specimen.json - v3.5.0] - 2023-08-22
+### Added
+Added timecourse module. Fixes #1511
+
+### [type/biomaterial/specimen_from_organism.json - v10.8.0] - 2023-08-22
+### Added
+Added timecourse module. Fixes #1511
+
+### [type/biomaterial/organoid.json - v11.5.0] - 2023-08-22
+### Added
+Added timecourse module. Fixes #1511
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/project/hca_bionetwork.json - v1.0.1] - 2023-05-22

--- a/docs/jsonBrowser/core.md
+++ b/docs/jsonBrowser/core.md
@@ -61,7 +61,7 @@ supplementary_files | A list of filenames of biomaterial-level supplementary fil
 biosamples_accession | A BioSamples accession. | string | no |  | BioSamples accession |  | SAMN00000000
 insdc_sample_accession | An International Nucleotide Sequence Database Collaboration (INSDC) sample accession. | string | no |  | INSDC sample accession |  | SRS0000000
 HDBR_accession | A Human Developmental Biology Resource (HDBR) sample accession. | string | no |  | HDBR accession |  | 34526; 14758, 2, liver
-timecourse | Information relating to a timecourse associated with this cell line. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
+timecourse | Information relating to a timecourse associated with this biomaterial. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
 
 ## Process core<a name='Process core'></a>
 _Information relevant to how a biomaterial or file was converted into another biomaterial or file._

--- a/docs/jsonBrowser/core.md
+++ b/docs/jsonBrowser/core.md
@@ -61,6 +61,7 @@ supplementary_files | A list of filenames of biomaterial-level supplementary fil
 biosamples_accession | A BioSamples accession. | string | no |  | BioSamples accession |  | SAMN00000000
 insdc_sample_accession | An International Nucleotide Sequence Database Collaboration (INSDC) sample accession. | string | no |  | INSDC sample accession |  | SRS0000000
 HDBR_accession | A Human Developmental Biology Resource (HDBR) sample accession. | string | no |  | HDBR accession |  | 34526; 14758, 2, liver
+timecourse | Information relating to a timecourse associated with this cell line. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
 
 ## Process core<a name='Process core'></a>
 _Information relevant to how a biomaterial or file was converted into another biomaterial or file._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -361,7 +361,6 @@ genus_species | The scientific binomial name for the species of the suspension. 
 selected_cell_types | The cell type(s) selected to be present in the suspension. | array | no | [See module  cell_type_ontology](module.md#cell-type-ontology) | Selected cell type(s) |  | 
 estimated_cell_count | Estimated number of cells in the suspension. | integer | no |  | Estimated cell count |  | 1; 2100
 plate_based_sequencing | Fields specific for plate-based sequencing experiments. | object | no | [See module  plate_based_sequencing](module.md#plate-based-sequencing) | Plate-based sequencing |  | 
-timecourse | Information relating to a timecourse associated with this cell suspension. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
 
 ## Cell line
 _Information about the cell line or cell culture biomaterial._
@@ -390,7 +389,6 @@ date_established | Date when the cell line was established. | string | no |  | D
 disease | Short description of any disease association to the cell type. | object | no | [See module  disease_ontology](module.md#disease-ontology) | Disease |  | 
 genus_species | The scientific binomial name for the species of the cell line. | array | no | [See module  species_ontology](module.md#species-ontology) | Genus species |  | 
 publication | A publication that cites the cell line creation. | object | no | [See module  publication](module.md#publication) | Publication |  | 
-timecourse | Information relating to a timecourse associated with this cell line. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
 
 ## Imaged specimen
 _Information about a tissue specimen after it has been sectioned and prepared for imaging._
@@ -434,7 +432,6 @@ height | Height of organism in Height unit. | string | no |  | Height |  | 160; 
 height_unit | The unit in which Height is expressed. | object | no | [See module  length_unit_ontology](module.md#length-unit-ontology) | Height unit |  | 
 weight | Weight of organism in Weight unit. | string | no |  | Weight |  | 60; 40-60
 weight_unit | The unit in which Weight is expressed. | object | no | [See module  mass_unit_ontology](module.md#mass-unit-ontology) | Weight unit |  | 
-timecourse | Information relating to a timecourse associated with this biomaterial. | object | no | [See module  timecourse](module.md#timecourse) | Timecourse |  | 
 
 ## Organoid
 _Information about an organoid biomaterial._

--- a/json_schema/core/biomaterial/biomaterial_core.json
+++ b/json_schema/core/biomaterial/biomaterial_core.json
@@ -85,7 +85,7 @@
             "guidelines": "Enter accession if sample has been obtained from the Human Developmental Biology Resource (HDBR)."
         },
         "timecourse": {
-            "description": "Information relating to a timecourse associated with this cell line.",
+            "description": "Information relating to a timecourse associated with this biomaterial.",
             "type": "object",
             "$ref": "module/biomaterial/timecourse.json",
             "user_friendly": "Timecourse"

--- a/json_schema/core/biomaterial/biomaterial_core.json
+++ b/json_schema/core/biomaterial/biomaterial_core.json
@@ -83,6 +83,12 @@
             "user_friendly": "HDBR accession",
             "example": "34526; 14758, 2, liver",
             "guidelines": "Enter accession if sample has been obtained from the Human Developmental Biology Resource (HDBR)."
+        },
+        "timecourse": {
+            "description": "Information relating to a timecourse associated with this cell line.",
+            "type": "object",
+            "$ref": "module/biomaterial/timecourse.json",
+            "user_friendly": "Timecourse"
         }
     }
 }

--- a/json_schema/property_migrations.json
+++ b/json_schema/property_migrations.json
@@ -1,6 +1,33 @@
 {
     "migrations": [
         {
+            "source_schema": "cell_line",
+            "property": "timecourse",
+            "target_schema": "cell_line",
+            "replaced_by": "biomaterial_core.timecourse",
+            "effective_from": "16.0.0",
+            "reason": "Timecourse module has been moved to biomaterial core",
+            "type": "moved property"
+        },
+        {
+            "source_schema": "donor_organism",
+            "property": "timecourse",
+            "target_schema": "donor_organism",
+            "replaced_by": "biomaterial_core.timecourse",
+            "effective_from": "16.0.0",
+            "reason": "Timecourse module has been moved to biomaterial core",
+            "type": "moved property"
+        },
+        {
+            "source_schema": "cell_suspension",
+            "property": "timecourse",
+            "target_schema": "cell_suspension",
+            "replaced_by": "biomaterial_core.timecourse",
+            "effective_from": "14.0.0",
+            "reason": "Timecourse module has been moved to biomaterial core",
+            "type": "moved property"
+        },
+        {
             "source_schema": "analysis_file",
             "property": "genome_assembly_version",
             "effective_from": "7.0.0",

--- a/json_schema/type/biomaterial/cell_line.json
+++ b/json_schema/type/biomaterial/cell_line.json
@@ -155,12 +155,6 @@
             "type": "object",
             "$ref": "module/project/publication.json",
             "user_friendly": "Publication"
-        },
-        "timecourse": {
-            "description": "Information relating to a timecourse associated with this cell line.",
-            "type": "object",
-            "$ref": "module/biomaterial/timecourse.json",
-            "user_friendly": "Timecourse"
         }
     }
 }

--- a/json_schema/type/biomaterial/cell_suspension.json
+++ b/json_schema/type/biomaterial/cell_suspension.json
@@ -83,12 +83,6 @@
             "type": "object",
             "$ref": "module/process/sequencing/plate_based_sequencing.json",
             "user_friendly": "Plate-based sequencing"
-        },
-        "timecourse": {
-            "description": "Information relating to a timecourse associated with this cell suspension.",
-            "type": "object",
-            "$ref": "module/biomaterial/timecourse.json",
-            "user_friendly": "Timecourse"
         }
      }
 }

--- a/json_schema/type/biomaterial/donor_organism.json
+++ b/json_schema/type/biomaterial/donor_organism.json
@@ -178,12 +178,6 @@
             "type": "object",
             "$ref": "module/ontology/mass_unit_ontology.json",
             "user_friendly": "Weight unit"
-        },
-        "timecourse": {
-            "description": "Information relating to a timecourse associated with this biomaterial.",
-            "type": "object",
-            "$ref": "module/biomaterial/timecourse.json",
-            "user_friendly": "Timecourse"
         }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,5 +1,1 @@
 Schema,Change type,Change message,Version,Date
-core/biomaterial/biomaterial_core,minor,Added timecourse module. Fixes #1511,,
-type/biomaterial.donor_organism,major,Removed timecourse module.,,
-type/biomaterial.cell_suspension,major,Removed timecourse module.,,
-type/biomaterial.cell_line,major,Removed timecourse module.,,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,5 @@
 Schema,Change type,Change message,Version,Date
+core/biomaterial/biomaterial_core,minor,Added timecourse module. Fixes #1511,,
+type/biomaterial.donor_organism,major,Removed timecourse module.,,
+type/biomaterial.cell_suspension,major,Removed timecourse module.,,
+type/biomaterial.cell_line,major,Removed timecourse module.,,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,9 +1,9 @@
 {
-    "last_update_date": "2023-05-22T11:01:09Z",
+    "last_update_date": "2023-08-22T11:35:16Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
-                "biomaterial_core": "8.2.0"
+                "biomaterial_core": "8.4.0"
             },
             "file": {
                 "file_core": "6.4.0"
@@ -89,12 +89,12 @@
         },
         "type": {
             "biomaterial": {
-                "cell_line": "15.1.0",
-                "cell_suspension": "13.3.0",
-                "donor_organism": "15.6.1",
-                "imaged_specimen": "3.3.0",
-                "organoid": "11.3.0",
-                "specimen_from_organism": "10.6.0"
+                "cell_line": "16.0.0",
+                "cell_suspension": "14.0.0",
+                "donor_organism": "16.0.0",
+                "imaged_specimen": "3.5.0",
+                "organoid": "11.5.0",
+                "specimen_from_organism": "10.8.0"
             },
             "file": {
                 "analysis_file": "7.0.0",


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

This is a remake of PR #1513 to clean up the commit tree.

For core/biomaterial/biomaterial_core.json schema:
-Added timecourse module

For type/biomaterial/donor_organism.json schema:
-Removed timecourse module

For type/biomaterial/cell_suspension.json schema:
-Removed timecourse module

For type/biomaterial/cell_line.json schema:
-Removed timecourse module

Reviews requested
-Major change, removing timecourse module from donor_organism, cell_line, and cell_suspension.
-Minor change, adding timecourse module to biomaterial core.
 
