### PR TITLE
Added transplant field to specimen_from_organism. Fixes #1531

### DIFF
--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -340,6 +340,7 @@ organ | The organ that the biomaterial came from. | object | yes | [See module  
 organ_parts | A term for a specific part of the organ that the biomaterial came from. | array | no | [See module  organ_part_ontology](module.md#organ-part-ontology) | Organ part |  | 
 diseases | Short description of known disease(s) of the specimen. | array | no | [See module  disease_ontology](module.md#disease-ontology) | Known disease(s) |  | 
 adjacent_diseases | Short description of the disease(s) adjacent to the specimen's collection site (e.g. breast cancer). | array | no | [See module  disease_ontology](module.md#disease-ontology) | Adjacent disease(s) |  | 
+transplant | Description of tissue sampled from a transplanted organ. | string | no |  | Transplanted tissue | tissue from transplanted organ, xenograft tissue | tissue from transplanted organ; xenograft tissue
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -340,7 +340,7 @@ organ | The organ that the biomaterial came from. | object | yes | [See module  
 organ_parts | A term for a specific part of the organ that the biomaterial came from. | array | no | [See module  organ_part_ontology](module.md#organ-part-ontology) | Organ part |  | 
 diseases | Short description of known disease(s) of the specimen. | array | no | [See module  disease_ontology](module.md#disease-ontology) | Known disease(s) |  | 
 adjacent_diseases | Short description of the disease(s) adjacent to the specimen's collection site (e.g. breast cancer). | array | no | [See module  disease_ontology](module.md#disease-ontology) | Adjacent disease(s) |  | 
-transplant | Description of tissue sampled from a transplanted organ. | string | no |  | Transplanted tissue | tissue from transplanted organ, xenograft tissue | tissue from transplanted organ; xenograft tissue
+transplant | Tissue or organ transplanted from a donor to a recipient. | string | no |  | Transplanted tissue | Allograft, Xenograft | Allograft; Xenograft
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -83,6 +83,17 @@
             "user_friendly": "Adjacent disease(s)",
             "guidelines": "If a healthy specimen is sampled from a site adjacent to diseased tissue, enter that tissue's disease here. If no diseased tissue is adjacent to the specimen, leave blank."
         },
+        "transplant": {
+            "description": "Description of tissue sampled from a transplanted organ.",
+            "type": "string",
+            "enum": [
+                "tissue from transplanted organ",
+                "xenograft tissue"
+            ],
+            "user_friendly": "Transplanted tissue",
+            "example": "tissue from transplanted organ; xenograft tissue",
+            "guidelines": "Should be one of: tissue from transplanted organ, xenograft tissue"
+        },
         "state_of_specimen": {
             "description": "State of the specimen at the time of collection.",
             "type": "object",

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -84,15 +84,15 @@
             "guidelines": "If a healthy specimen is sampled from a site adjacent to diseased tissue, enter that tissue's disease here. If no diseased tissue is adjacent to the specimen, leave blank."
         },
         "transplant": {
-            "description": "Description of tissue sampled from a transplanted organ.",
+            "description": "Tissue or organ transplanted from a donor to a recipient.",
             "type": "string",
             "enum": [
-                "tissue from transplanted organ",
-                "xenograft tissue"
+                "Allograft",
+                "Xenograft"
             ],
             "user_friendly": "Transplanted tissue",
-            "example": "tissue from transplanted organ; xenograft tissue",
-            "guidelines": "Should be one of: tissue from transplanted organ, xenograft tissue"
+            "example": "Allograft; Xenograft",
+            "guidelines": "If the sampled tissue or organ were transplanted fill with one of: Allograft, Xenograft"
         },
         "state_of_specimen": {
             "description": "State of the specimen at the time of collection.",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/biomaterial/specimen_from_organism,minor,Added new transplant field to specimen. Fixes #1531,,


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->

### Release notes

For `specimen_from_organism.json` schema:
- added `transplant` field

### Why are these changes needed?
 The new field is needed to clearly indicate whether the sampled tissue comes from a transplanted organ. This field was requested by the kidney Bionetwork.

### Reviews requested
This is a minor schema changes, all DCP2 reviewers need to review