### PR TITLE
adds DUOS id field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,11 @@ Starting after v5.0.0 release, updates will be declared for schemas independentl
 and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). Unreleased changes may be indicated under the `Unreleased` heading.
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
-## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
+
+### [type/project/project.json - v19.0.0] - 2024-03-15
+### Added
+Added DUOS id field. Fixes #1550
+
 
 ### [type/project/project.json - v18.0.0] - 2024-03-04
 ### Added

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -328,7 +328,7 @@ biostudies_accessions | A BioStudies study accession. | array | no |  | BioStudi
 funders | Funding source(s) supporting the project. | array | yes | [See module  funder](module.md#funder) | Funding source(s) |  | 
 estimated_cell_count | An estimated number of cells in this project | integer | no |  | Estimated cell count |  | 10000; 2100000
 data_use_restriction | Data use restrictions that apply to the project. | string | yes |  | Data use restriction | NRES, GRU, GRU-NCU | GRU
-DUOS_id | A DUOS dataset id. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
+duos_id | A DUOS dataset id. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
 
 ## Specimen from organism
 _Information about the specimen that was collected from the donor organism._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -328,7 +328,7 @@ biostudies_accessions | A BioStudies study accession. | array | no |  | BioStudi
 funders | Funding source(s) supporting the project. | array | yes | [See module  funder](module.md#funder) | Funding source(s) |  | 
 estimated_cell_count | An estimated number of cells in this project | integer | no |  | Estimated cell count |  | 10000; 2100000
 data_use_restriction | Data use restrictions that apply to the project. | string | yes |  | Data use restriction | NRES, GRU, GRU-NCU | GRU
-DUOS_id | A DUOS study accession. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
+DUOS_id | A DUOS dataset id. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
 
 ## Specimen from organism
 _Information about the specimen that was collected from the donor organism._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -328,7 +328,7 @@ biostudies_accessions | A BioStudies study accession. | array | no |  | BioStudi
 funders | Funding source(s) supporting the project. | array | yes | [See module  funder](module.md#funder) | Funding source(s) |  | 
 estimated_cell_count | An estimated number of cells in this project | integer | no |  | Estimated cell count |  | 10000; 2100000
 data_use_restriction | Data use restrictions that apply to the project. | string | yes |  | Data use restriction | NRES, GRU, GRU-NCU | GRU
-DUOS_id | A DUOS study accession. | array | no |  | DUOS id |  | DUOS-000108; DUOS-000114
+DUOS_id | A DUOS study accession. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
 
 ## Specimen from organism
 _Information about the specimen that was collected from the donor organism._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -328,7 +328,7 @@ biostudies_accessions | A BioStudies study accession. | array | no |  | BioStudi
 funders | Funding source(s) supporting the project. | array | yes | [See module  funder](module.md#funder) | Funding source(s) |  | 
 estimated_cell_count | An estimated number of cells in this project | integer | no |  | Estimated cell count |  | 10000; 2100000
 data_use_restriction | Data use restrictions that apply to the project. | string | yes |  | Data use restriction | NRES, GRU, GRU-NCU | GRU
-duos_id | A DUOS dataset id. | string | no |  | DUOS id |  | DUOS-000108; DUOS-000114
+duos_id | A DUOS dataset id. | string | no |  | DUOS ID |  | DUOS-000108; DUOS-000114
 
 ## Specimen from organism
 _Information about the specimen that was collected from the donor organism._

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -328,6 +328,7 @@ biostudies_accessions | A BioStudies study accession. | array | no |  | BioStudi
 funders | Funding source(s) supporting the project. | array | yes | [See module  funder](module.md#funder) | Funding source(s) |  | 
 estimated_cell_count | An estimated number of cells in this project | integer | no |  | Estimated cell count |  | 10000; 2100000
 data_use_restriction | Data use restrictions that apply to the project. | string | yes |  | Data use restriction | NRES, GRU, GRU-NCU | GRU
+DUOS_id | A DUOS study accession. | array | no |  | DUOS id |  | DUOS-000108; DUOS-000114
 
 ## Specimen from organism
 _Information about the specimen that was collected from the donor organism._

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -177,6 +177,30 @@
             "user_friendly": "Data use restriction",
             "guidelines": "Must be one of: NRES, GRU, GRU-NCU. The use restriction codes are based on the DUO ontology where NRES corresponds to DUO:0000004, GRU corresponds to DUO:0000042, GRU-NCU corresponds to a combination of DUO:0000042 and DUO:0000046",
             "example": "GRU"
+        },
+        "DUOS_id": {
+            "description": "A DUOS study accession.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^DUOS-\\d{1,6}$"
+            },
+            "example": "DUOS-000108; DUOS-000114",
+            "user_friendly": "DUOS id",
+            "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS id here."
         }
+    },
+    "if" : {
+        "properties": {
+            "data_use_restriction": {
+                "enum": [
+                    "GRU",
+                    "GRU-NCU"
+                ]
+            }
+        }
+    },
+    "then" : {
+        "required": ["DUOS_id"]
     }
 }

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -178,7 +178,7 @@
             "guidelines": "Must be one of: NRES, GRU, GRU-NCU. The use restriction codes are based on the DUO ontology where NRES corresponds to DUO:0000004, GRU corresponds to DUO:0000042, GRU-NCU corresponds to a combination of DUO:0000042 and DUO:0000046",
             "example": "GRU"
         },
-        "DUOS_id": {
+        "duos_id": {
             "description": "A DUOS dataset id.",
             "type": "string",
             "pattern": "^DUOS-\\d{1,6}$",
@@ -198,14 +198,14 @@
         }
     },
     "then" : {
-        "required": ["DUOS_id"]
+        "required": ["duos_id"]
     },
     "else" : {
         "properties": {
             "data_use_restriction" : {
                 "enum": ["NRES"]
             },
-            "DUOS_id" : {
+            "duos_id" : {
                 "maxLength": 0
             }
         }

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -179,7 +179,7 @@
             "example": "GRU"
         },
         "DUOS_id": {
-            "description": "A DUOS study accession.",
+            "description": "A DUOS dataset id.",
             "type": "string",
             "pattern": "^DUOS-\\d{1,6}$",
             "example": "DUOS-000108; DUOS-000114",

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -180,11 +180,8 @@
         },
         "DUOS_id": {
             "description": "A DUOS study accession.",
-            "type": "array",
-            "items": {
-                "type": "string",
-                "pattern": "^DUOS-\\d{1,6}$"
-            },
+            "type": "string",
+            "pattern": "^DUOS-\\d{1,6}$",
             "example": "DUOS-000108; DUOS-000114",
             "user_friendly": "DUOS id",
             "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS id here."
@@ -202,5 +199,15 @@
     },
     "then" : {
         "required": ["DUOS_id"]
+    },
+    "else" : {
+        "properties": {
+            "data_use_restriction" : {
+                "enum": ["NRES"]
+            },
+            "DUOS_id" : {
+                "maxLength": 0
+            }
+        }
     }
 }

--- a/json_schema/type/project/project.json
+++ b/json_schema/type/project/project.json
@@ -181,10 +181,10 @@
         "duos_id": {
             "description": "A DUOS dataset id.",
             "type": "string",
-            "pattern": "^DUOS-\\d{1,6}$",
+            "pattern": "^DUOS-\\d{6}$",
             "example": "DUOS-000108; DUOS-000114",
-            "user_friendly": "DUOS id",
-            "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS id here."
+            "user_friendly": "DUOS ID",
+            "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS ID here."
         }
     },
     "if" : {

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,2 @@
 Schema,Change type,Change message,Version,Date
-type/project/project.json,major,"Adds DUOS id field. Fixes #1550",,
+type/project/project.json,major,"Added DUOS id field. Fixes #1550",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/project/project.json,major,"Added DUOS id field. Fixes #1550",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/project/project.json,major,"Adds DUOS id field. Fixes #1550",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2024-03-04T14:00:53Z",
+    "last_update_date": "2024-03-15T11:43:55Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -110,7 +110,7 @@
                 "process": "9.2.0"
             },
             "project": {
-                "project": "18.0.0"
+                "project": "19.0.0"
             },
             "protocol": {
                 "analysis": {

--- a/src/schema_linter.py
+++ b/src/schema_linter.py
@@ -16,7 +16,7 @@ cwd = os.getcwd().split("/")[-1]
 
 required_schema_fields = ['$schema', 'description', 'additionalProperties', 'title', 'name', 'type', 'properties']
 
-allowed_schema_fields = ['$schema', 'description', 'additionalProperties', 'required', 'title', 'name', 'type', 'properties', 'definitions', 'dependencies']
+allowed_schema_fields = ['$schema', 'description', 'additionalProperties', 'required', 'title', 'name', 'type', 'properties', 'definitions', 'dependencies', 'if', 'then', 'else']
 
 # Properties
 


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->
Fixes #1550 

#### Rationale

1.  The DUOS id should be required only if the project is managed access (`data_use_restriction = GRU` or `GRU-NCU`)
2. If the project is open access (`data_use_restriction = NRES` ) `DUOS_id` should be forbidden. This way if a project is erroneously marked as open access we can’t export it with a DUOS id.

#### Implementation:
1. The if block allows to conditionally require a field
2. To make sure that `DUOS_id` is disallowed for open access projects it should be conditionally defined for `data_use_restriction = GRU` or `GRU-NCU`. 
This is not possible because `additionalProperties` is set to false, which means that any property not defined in the main property section will fail validation. Removing `additionalProperties : false` is not an option because then any undeclared property would also be valid.
In draft 9 by the keyword `unevaluatedProperties` allows to define properties in subschemas, but we are using draft7 so this option is not available to us right now.
The compromise I made is to require the length of the `DUOS_id` to be 0, so that if the `data_use_restriction` isn’t set correctly the schema will not validate.



### Release notes

For type/project/project.json schema:
- Adds `DUOS_id` field
 
