### PR TITLE
Added intron_inclusion field in analysis_protocol. Fixes#1554

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [type/protocol/analysis/analysis_protocol.json - v10.3.0] - 2024-04-15
+### Added
+Added intron_inclusion field in analysis_protocol Fixes#1554
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [type/biomaterial/specimen_from_organism.json - v10.9.0] - 2024-03-22

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -148,6 +148,7 @@ matrix | Information related to protocols that output a matrix. | object | no | 
 alignment_software | Name of alignment software used to map FASTQ files to reference genome. | string | no |  | Alignment software |  | Cellranger; kallisto bustools; GSNAP; STAR
 alignment_software_version | Version of alignment software used to map FASTQ files to reference genome. | string | no |  | Alignment software version |  | v2.0.1; 2.4.2a; v0.45.2
 gene_annotation_version | The Ensembl release version accession number or NCBI RefSeq assembly version used for gene annotation. | string | no |  | Gene annotation version |  | v110; GCF_000001405.40; GCF_000001635.27
+intron_inclusion | Whether introns were included in the alignment process during read counting. | boolean | no |  | Intron inclusion |  | Should be one of: yes, or no.
 
 ## Aggregate generation protocol
 _Information about how cultured cells are developed into cell aggregates._

--- a/json_schema/type/protocol/analysis/analysis_protocol.json
+++ b/json_schema/type/protocol/analysis/analysis_protocol.json
@@ -80,6 +80,12 @@
             "pattern": "^v\\d{2,}$|^GCF_\\d{9}\\.\\d+$",
             "user_friendly": "Gene annotation version",
             "example": "v110; GCF_000001405.40; GCF_000001635.27"
+        },
+        "intron_inclusion": {
+            "description": "Whether introns were included in the alignment process during read counting.",
+            "type": "boolean",
+            "user_friendly": "Intron inclusion",
+            "example": "Should be one of: yes, or no."
         }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-type/protocol/analysis/analysis_protocol,minor,"Added intron_inclusion field in analysis_protocol Fixes#1554",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/protocol/analysis/analysis_protocol,minor,"Added intron_inclusion field in analysis_protocol Fixes#1554",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2024-03-22T11:00:33Z",
+    "last_update_date": "2024-04-15T10:44:17Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -114,7 +114,7 @@
             },
             "protocol": {
                 "analysis": {
-                    "analysis_protocol": "10.2.0"
+                    "analysis_protocol": "10.3.0"
                 },
                 "biomaterial_collection": {
                     "aggregate_generation_protocol": "2.1.0",


### PR DESCRIPTION
### Release notes

For analysis_protocol.json schema:
- `intron_inclusion`
 
### Why are these changes needed?

This field is needed to record whether introns were included in the alignment process during read counting. 
Is one of the upcoming Tier 1 metadata proposed from HCA Integration Teams & Bionetworks

### Reviews requested

- Need 5 Reviewers to approve because this is a minor update
