### PR TITLE
Added smoking related fields in medical_history module. Fix #1565

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -473,7 +473,9 @@ Property name | Description | Type | Required? | Object reference? | User friend
 --- | --- | --- | --- | --- | --- | --- | --- 
 alcohol_history | Estimated amount of alcohol consumed per day. | string | no |  | Alcohol history |  | 3-6 alcohol units/day; 1 drink per day
 medication | Medications the individual was taking at time of biomaterial collection. | string | no |  | Medications |  | Naproxen 500mg/day; Citalopram 20mg/day
-smoking_history | Estimated number of cigarettes smoked per day. | string | no |  | Smoking history |  | 20 cigarettes/day for 25 years, stopped 2000
+smoking_status | Whether the individual is actively, was formerly or never consumed smoking tobacco products like cigarettes, cigars, pipe, betel nut chewing etc. | string | no |  | Smoking status | active, former, never | Should be one of: active, former, never.
+smoking_pack_years | Estimated number of packs (20 cigarettes) smoked per day multiplied by the number of years the individual was smoking. | number | no |  | Smoking pack years |  | 4.55
+years_since_smoking_cessation | If smoking status is 'former', specify the number of years since smoking cessation. | integer | no |  | Years since smoking cessation |  | 12
 nutritional_state | Nutritional state of individual at time of biomaterial collection. | string | no |  | Nutritional state | normal, fasting, feeding tube removed | Should be one of: normal, fasting, or feeding tube removed.
 test_results | Results from medical tests performed on the individual. | string | no |  | Test results |  | lipid panel shows normal level of LDL (124 mg/dL); HIV, HBV, HCV: Negative
 treatment | Treatments the individual has undergone prior to biomaterial collection. | string | no |  | Treatments |  | Patient treated with antibiotics for a urinary tract infection; Patient treated with chemotherapy (Epirubicin, cisplatin, capecitabine) to treat stomach cancer

--- a/json_schema/module/biomaterial/medical_history.json
+++ b/json_schema/module/biomaterial/medical_history.json
@@ -31,12 +31,30 @@
             "example": "Naproxen 500mg/day; Citalopram 20mg/day",
             "guidelines": "Enter the medication and dosage. Separate multiple medications with commas."
         },
-        "smoking_history": {
-            "description": "Estimated number of cigarettes smoked per day.",
+        "smoking_status": {
+            "description": "Whether the individual is actively, was formerly or never consumed smoking tobacco products like cigarettes, cigars, pipe, betel nut chewing etc.",
             "type": "string",
-            "user_friendly": "Smoking history",
-            "example": "20 cigarettes/day for 25 years, stopped 2000",
-            "guidelines": "Enter an estimated number of cigarettes smoked per day and for how many years."
+            "enum": [
+                "active",
+                "former",
+                "never"
+            ],
+            "user_friendly": "Smoking status",
+            "example": "Should be one of: active, former, never."
+        },
+        "smoking_pack_years": {
+            "description": "Estimated number of packs (20 cigarettes) smoked per day multiplied by the number of years the individual was smoking.",
+            "type": "number",
+            "user_friendly": "Smoking pack years",
+            "minimum": 0,
+            "example": 4.55
+        },
+        "years_since_smoking_cessation": {
+            "description": "If smoking status is 'former', specify the number of years since smoking cessation.",
+            "type": "integer",
+            "user_friendly": "Years since smoking cessation",
+            "minimum": 0,
+            "example": 12
         },
         "nutritional_state": {
             "description": "Nutritional state of individual at time of biomaterial collection.",

--- a/json_schema/property_migrations.json
+++ b/json_schema/property_migrations.json
@@ -1,6 +1,13 @@
 {
     "migrations": [
         {
+            "source_schema": "medical_history",
+            "property": "smoking_history",
+            "effective_from" : "6.0.0",
+            "reason": "Field standardization",
+            "type": "renamed property"
+        },      
+        {
             "source_schema": "project",
             "property": "data_use_restriction",
             "effective_from": "18.0.0",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,3 @@
 Schema,Change type,Change message,Version,Date
+module/biomaterial/medical_history,minor,"Added smoking related fields in medical_history module. Fix #1565",,
+module/biomaterial/medical_history,major,"Changed smoking_history name in medical_history module. Fix #1565",,


### PR DESCRIPTION
### Release notes

For `medical_history.json` schema:
- `smoking_status`
- `smoking_pack_years`
- `years_since_smoking_cessation`
- removed `smoking_history`
 
### Reviews requested

- Need 5 Reviewers to approve because this is a major update
