### PR TITLE
Add `drs_uri` to DCP/2 file descriptor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [system/file_descriptor.json - v2.1.0] - 2024-09-24
+### Added
+Added 'drs_uri' property to file_descriptor
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 

--- a/json_schema/system/file_descriptor.json
+++ b/json_schema/system/file_descriptor.json
@@ -94,6 +94,13 @@
       "user_friendly": "S3 ETag",
       "type": "string",
       "example": "c92e5374ac0a53b228d4c1511c2d2842-63"
+    },
+    "drs_uri": {
+      "description": "Data Repository Service URI pointing at this file. If this property is absent, a data file exists in the repository containing this descriptor. If this property is present and not `null`, a data file exists in another repository at the specified URI. If this property is present but `null`, the data file is not available, but will likely become available in the future, along with an updated descriptor referencing it.",
+      "user_friendly": "Data Repository Service URI",
+      "type": ["string", "null"],
+      "format": "uri",
+      "example": "drs://drs.example.org/314159"
     }
   }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+system/file_descriptor,minor,"Added 'drs_uri' property to file_descriptor",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-system/file_descriptor,minor,"Added 'drs_uri' property to file_descriptor",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2024-09-16T14:52:03Z",
+    "last_update_date": "2024-09-24T15:16:27Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -83,7 +83,7 @@
             }
         },
         "system": {
-            "file_descriptor": "2.0.0",
+            "file_descriptor": "2.1.0",
             "license": "1.0.0",
             "links": "3.1.0",
             "provenance": "1.1.0"


### PR DESCRIPTION
Continued from https://github.com/HumanCellAtlas/metadata-schema/pull/1437

The immediate need is for LungMAP but this property could be useful in other contexts as it allows for files to be hosted by DRS implementations other than TDR.

I took Andrew's changes from that old PR, squashed them down into a single commit and removed what I believe to be cruft. The branch is based on staging.