### PR TITLE
Fixed schema_linter.py and human_readable_json.py script bugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
+
 ### [type/biomaterial/donor_organism.json - v17.1.0] - 2024-12-11
 ### Added
 Added non-required gender identity field.
@@ -14,8 +16,6 @@ Added non-required gender identity field.
 ### [module/ontology/gender_identity_ontology.json - v1.0.0] - 2024-12-11
 ### Added
 Added ontology module for gender identity.
-
-## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/biomaterial/medical_history.json - v7.0.0] - 2024-11-06
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
+
 ### [module/biomaterial/medical_history.json - v7.0.0] - 2024-11-06
 ### Changed
 Changed medication field type Fix#1589
@@ -18,8 +20,6 @@ Added medication ontology module Fix#1589
 ### [type/biomaterial/donor_organism.json - v17.0.0] - 2024-11-06
 ### Changed
 Changed medication field type Fix#1589
-
-## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [type/biomaterial/donor_organism.json - v16.4.0] - 2024-10-21
 ### Added


### PR DESCRIPTION
### Update notes

#1597

For [schema_linter.py](https://github.com/HumanCellAtlas/metadata-schema/blob/master/src/schema_linter.py):
- fixed error of array in property type
- added allowed values in `allowed_schema_fields` & "valid JSON types"
- replaced OLS provider url & removed functionality to select OLS environment in script arguments

For [human_readable_json.py](https://github.com/HumanCellAtlas/metadata-schema/blob/master/src/human_readable_json.py):
- fixed bug with numeric enum values
 

### Reviews requested

- No reviewers since this is not a schema update
