### PR TITLE
Updated medication ontology sources

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,18 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [module/ontology/medication_ontology.json - v2.0.0] - 2025-02-28
+### Changed
+Changed ontology source for the medication_ontology
+
+### [module/biomaterial/medical_history.json - v8.0.0] - 2025-02-28
+### Changed
+Changed ontology source for the medication_ontology
+
+### [type/biomaterial/donor_organism.json - v18.0.0] - 2025-02-28
+### Changed
+Changed ontology source for the medication_ontology
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [type/protocol/biomaterial_collection/dissociation_protocol.json - v6.3.0] - 2025-01-21

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -232,9 +232,9 @@ Location: module/ontology/medication_ontology.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-text | Medication(s) the individual was taking at time of biomaterial collection. | string | yes |  | Medication |  | Ibuprofen Lysine; Bisoprolol; salbutamol suspension
-ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Medication ontology ID |  | NCIT:C72809; NCIT:C61653; DRON:00001511
-ontology_label | The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field. | string | no |  | Medication ontology label |  | bisoprolol; paracetamol; loratadine
+text | Medication(s) the individual was taking at time of biomaterial collection. | string | yes |  | Medication |  | Ibuprofen Lysine; Bisoprolol; Ambroxol Hydrochloride
+ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Medication ontology ID |  | NCIT:C72809; NCIT:C61653; NCIT:C78113
+ontology_label | The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field. | string | no |  | Medication ontology label |  | Ibuprofen Lysine; Bisoprolol; Ambroxol Hydrochloride
 
 ## File format ontology<a name='File format ontology'></a>
 _A term that may be associated with a file format-related ontology term._

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -232,8 +232,8 @@ Location: module/ontology/medication_ontology.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-text | Medication(s) the individual was taking at time of biomaterial collection. | string | yes |  | Medication |  | bisoprolol; paracetamol; loratadine
-ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Medication ontology ID |  | CHEBI:3127; CHEBI:46195; CHEBI:6538
+text | Medication(s) the individual was taking at time of biomaterial collection. | string | yes |  | Medication |  | Ibuprofen Lysine; Bisoprolol; salbutamol suspension
+ontology | An ontology term identifier in the form prefix:accession. | string | no |  | Medication ontology ID |  | NCIT:C72809; NCIT:C61653; DRON:00001511
 ontology_label | The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field. | string | no |  | Medication ontology label |  | bisoprolol; paracetamol; loratadine
 
 ## File format ontology<a name='File format ontology'></a>

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -287,7 +287,7 @@ text | The name of the strain to which the organism belongs. | string |  | Strai
 ### Medication ontology<a name='Medication ontology'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
-text | Medication(s) the individual was taking at time of biomaterial collection. | string |  | Medication |  | bisoprolol; paracetamol; loratadine
+text | Medication(s) the individual was taking at time of biomaterial collection. | string |  | Medication |  | Ibuprofen Lysine; Bisoprolol; salbutamol suspension
 ### File format ontology<a name='File format ontology'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -287,7 +287,7 @@ text | The name of the strain to which the organism belongs. | string |  | Strai
 ### Medication ontology<a name='Medication ontology'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
-text | Medication(s) the individual was taking at time of biomaterial collection. | string |  | Medication |  | Ibuprofen Lysine; Bisoprolol; salbutamol suspension
+text | Medication(s) the individual was taking at time of biomaterial collection. | string |  | Medication |  | Ibuprofen Lysine; Bisoprolol; Ambroxol Hydrochloride
 ### File format ontology<a name='File format ontology'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 

--- a/json_schema/module/ontology/medication_ontology.json
+++ b/json_schema/module/ontology/medication_ontology.json
@@ -24,20 +24,20 @@
             "description": "Medication(s) the individual was taking at time of biomaterial collection.",
             "type": "string",
             "user_friendly": "Medication",
-            "example": "bisoprolol; paracetamol; loratadine"
+            "example": "Ibuprofen Lysine; Bisoprolol; salbutamol suspension"
         },
         "ontology": {
             "description": "An ontology term identifier in the form prefix:accession.",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:dron"],
-                "classes": ["BFO:0000040"],
+                "ontologies" : ["obo:ncit","obo:dron"],
+                "classes": ["ncit:C1908", "bfo:0000002"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false
             },
             "user_friendly": "Medication ontology ID",
-            "example": "CHEBI:3127; CHEBI:46195; CHEBI:6538"
+            "example": "NCIT:C72809; NCIT:C61653; DRON:00001511"
         },
         "ontology_label": {
             "description": "The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field.",

--- a/json_schema/module/ontology/medication_ontology.json
+++ b/json_schema/module/ontology/medication_ontology.json
@@ -31,7 +31,7 @@
             "type": "string",
             "graph_restriction":  {
                 "ontologies" : ["obo:ncit"],
-                "classes": ["ncit:C1505", "ncit:C54060", "ncit:C1909", "ncit:C129986", "ncit:C1899", "ncit:C913"],
+                "classes": ["ncit:C1505", "ncit:C54060", "ncit:C1909", "ncit:C129986", "ncit:C1899", "ncit:C1913"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/medication_ontology.json
+++ b/json_schema/module/ontology/medication_ontology.json
@@ -31,7 +31,7 @@
             "type": "string",
             "graph_restriction":  {
                 "ontologies" : ["obo:ncit"],
-                "classes": ["ncit:C1505", "ncit:C54060", "ncit:C1909", "ncit:C129986", "ncit:C1899", "ncit:C1913"],
+                "classes": ["NCIT:C1505", "NCIT:C54060", "NCIT:C1909", "NCIT:C129986", "NCIT:C1899", "NCIT:C1913"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false

--- a/json_schema/module/ontology/medication_ontology.json
+++ b/json_schema/module/ontology/medication_ontology.json
@@ -24,26 +24,26 @@
             "description": "Medication(s) the individual was taking at time of biomaterial collection.",
             "type": "string",
             "user_friendly": "Medication",
-            "example": "Ibuprofen Lysine; Bisoprolol; salbutamol suspension"
+            "example": "Ibuprofen Lysine; Bisoprolol; Ambroxol Hydrochloride"
         },
         "ontology": {
             "description": "An ontology term identifier in the form prefix:accession.",
             "type": "string",
             "graph_restriction":  {
-                "ontologies" : ["obo:ncit","obo:dron"],
-                "classes": ["ncit:C1908", "bfo:0000002"],
+                "ontologies" : ["obo:ncit"],
+                "classes": ["ncit:C1505", "ncit:C54060", "ncit:C1909", "ncit:C129986", "ncit:C1899", "ncit:C913"],
                 "relations": ["rdfs:subClassOf"],
                 "direct": false,
                 "include_self": false
             },
             "user_friendly": "Medication ontology ID",
-            "example": "NCIT:C72809; NCIT:C61653; DRON:00001511"
+            "example": "NCIT:C72809; NCIT:C61653; NCIT:C78113"
         },
         "ontology_label": {
             "description": "The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field.",
             "type": "string",
             "user_friendly": "Medication ontology label",
-            "example": "Ibuprofen Lysine; Bisoprolol; salbutamol suspension"
+            "example": "Ibuprofen Lysine; Bisoprolol; Ambroxol Hydrochloride"
         }
     }
 }

--- a/json_schema/module/ontology/medication_ontology.json
+++ b/json_schema/module/ontology/medication_ontology.json
@@ -43,7 +43,7 @@
             "description": "The preferred label for the ontology term referred to in the ontology field. This may differ from the user-supplied value in the text field.",
             "type": "string",
             "user_friendly": "Medication ontology label",
-            "example": "bisoprolol; paracetamol; loratadine"
+            "example": "Ibuprofen Lysine; Bisoprolol; salbutamol suspension"
         }
     }
 }

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,1 @@
 Schema,Change type,Change message,Version,Date
-module/ontology/medication_ontology,major,Changed ontology source for the medication_ontology,,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+module/ontology/medication_ontology,major,Changed ontology source for the medication_ontology,,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2025-01-21T10:14:27Z",
+    "last_update_date": "2025-02-28T10:45:54Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -26,7 +26,7 @@
                 "familial_relationship": "6.0.3",
                 "growth_conditions": "6.4.2",
                 "human_specific": "1.0.11",
-                "medical_history": "7.0.0",
+                "medical_history": "8.0.0",
                 "medical_tests": "1.0.0",
                 "mouse_specific": "1.0.8",
                 "preservation_storage": "6.1.1",
@@ -51,7 +51,7 @@
                 "library_amplification_ontology": "1.2.5",
                 "library_construction_ontology": "1.2.5",
                 "mass_unit_ontology": "5.3.5",
-                "medication_ontology": "1.0.0",
+                "medication_ontology": "2.0.0",
                 "microscopy_ontology": "1.0.5",
                 "organ_ontology": "5.3.7",
                 "organ_part_ontology": "5.3.5",
@@ -95,7 +95,7 @@
             "biomaterial": {
                 "cell_line": "16.0.0",
                 "cell_suspension": "14.0.0",
-                "donor_organism": "17.1.0",
+                "donor_organism": "18.0.0",
                 "imaged_specimen": "3.5.0",
                 "organoid": "11.5.0",
                 "specimen_from_organism": "10.9.0"


### PR DESCRIPTION
### Release notes

#1604 

For `medication_ontology.json` schema:
- `v2.0.0`: Change the source ontology from [DRON:bfo:0000040](https://www.ebi.ac.uk/ols4/ontologies/dron/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FBFO_0000040?lang=en) to 
* Dietary Supplement - [ncit:C1505](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C1505)
* Bioactive Food Component - [ncit:C54060](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C54060)
* Pharmacologic Substance - [ncit:C1909](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C1909)
* Traditional Chinese Medicine Formulation - [ncit:C129986](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C129986)
* Physiology-Regulatory Factor - [ncit:C1899](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C1899)
* Drug or Chemical by Structure - [ncit:C1913](https://www.ebi.ac.uk/ols4/ontologies/ncit/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FNCIT_C1913) 
 

### Reviews requested

- Need 4 Reviewers to approve because this is a major update