### PR TITLE
Added collection_institute in specimen_from_organism.Fix#1606

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
+
 ### [type/protocol/biomaterial_collection/dissociation_protocol.json - v6.3.0] - 2025-01-21
 ### Changed
 Changed user_friendly name of reagent field
@@ -26,8 +28,6 @@ Added optional digestion_temperature field
 ### [type/protocol/biomaterial_collection/dissociation_protocol.json - v6.7.0] - 2025-01-21
 ### Added
 Added optional digestion_solution field
-
-## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/project/hca_bionetwork.json - v2.0.0] - 2025-01-20
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and (starting with v4.0.0) this project adheres to [Semantic Versioning](http://
 
 ## [Unreleased](https://github.com/HumanCellAtlas/metadata-schema/tree/staging)
 
+### [module/biomaterial/collection_institute.json - v1.0.0] - 2025-03-24
+### Added
+Added collection_institute module.Issue1606
+
+### [type/biomaterial/specimen_from_organism.json - v10.10.0] - 2025-03-24
+### Added
+Added optional collection_institute module in specimen_from_organism.Issue1606
+
 ## [Released](https://github.com/HumanCellAtlas/metadata-schema/)
 
 ### [module/ontology/medication_ontology.json - v2.0.0] - 2025-02-28

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -482,6 +482,17 @@ dlco_predicted_percent | Indicate the percentage of the predicted DLCO, based on
 kco | Indicate the transfer coefficient of the lung for carbon monoxide (KCO) in mmol/min/kPa/L if available. | number | no |  | KCO |  | 5; 6; 4.5
 kco_predicted_percent | Indicate the percentage of the predicted KCO, based on patient demographics, if available. | number | no |  | KCO percent of predicted |  | 90; 98; 85
 
+## Collection institute<a name='Collection institute'></a>
+_Information about collection institute location._
+
+Location: module/biomaterial/collection_institute.json
+
+Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- | --- 
+latitude | The latitute of the collection institute, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
+longitude | The longitude of the collection institute, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
+name | The name of the collection institute. | string | no |  | Collection institute name |  | University of California, San Francisco
+
 ## Disease profile<a name='Disease profile'></a>
 _Information about specific diseases profile of the individual._
 

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -489,9 +489,9 @@ Location: module/biomaterial/collection_institute.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
+name | The name of the collection institute. | string | yes |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
 latitude | The latitute of the collection institute, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
 longitude | The longitude of the collection institute, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
-name | The name of the collection institute. | string | no |  | Collection institute name |  | University of California, San Francisco
 
 ## Disease profile<a name='Disease profile'></a>
 _Information about specific diseases profile of the individual._

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -489,9 +489,9 @@ Location: module/biomaterial/collection_institute.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-name | Name of the collection institute. | string | yes |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
-latitude | Latitute of the collection institute, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
-longitude | Longitude of the collection institute, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
+name | Name of the institute where the biomaterial was collected on. | string | yes |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
+latitude | Latitute of the institute where the biomaterial was collected on, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
+longitude | Longitude of the institute where the biomaterial was collected on, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
 
 ## Disease profile<a name='Disease profile'></a>
 _Information about specific diseases profile of the individual._

--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -489,9 +489,9 @@ Location: module/biomaterial/collection_institute.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-name | The name of the collection institute. | string | yes |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
-latitude | The latitute of the collection institute, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
-longitude | The longitude of the collection institute, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
+name | Name of the collection institute. | string | yes |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
+latitude | Latitute of the collection institute, in decimal degrees. | string | no |  | Collection institute latitude |  | 52.1; -0.127541; 38.045956
+longitude | Longitude of the collection institute, in decimal degrees. | string | no |  | Collection institute longitude |  | 0.1; -84.512016; 23.792138
 
 ## Disease profile<a name='Disease profile'></a>
 _Information about specific diseases profile of the individual._

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -363,7 +363,7 @@ _There are no required properties in schema Medical tests_
 ### Collection institute<a name='Collection institute'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
-name | The name of the collection institute. | string |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
+name | Name of the collection institute. | string |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
 ### Disease profile<a name='Disease profile'></a>
 _There are no required properties in schema Disease profile_
 ### Preservation and storage<a name='Preservation and storage'></a>

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -363,7 +363,7 @@ _There are no required properties in schema Medical tests_
 ### Collection institute<a name='Collection institute'></a>
 Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- 
-name | Name of the collection institute. | string |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
+name | Name of the institute where the biomaterial was collected on. | string |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
 ### Disease profile<a name='Disease profile'></a>
 _There are no required properties in schema Disease profile_
 ### Preservation and storage<a name='Preservation and storage'></a>

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -360,6 +360,8 @@ _There are no required properties in schema Human-specific_
 _There are no required properties in schema Growth conditions_
 ### Medical tests<a name='Medical tests'></a>
 _There are no required properties in schema Medical tests_
+### Collection institute<a name='Collection institute'></a>
+_There are no required properties in schema Collection institute_
 ### Disease profile<a name='Disease profile'></a>
 _There are no required properties in schema Disease profile_
 ### Preservation and storage<a name='Preservation and storage'></a>

--- a/docs/jsonBrowser/required_fields.md
+++ b/docs/jsonBrowser/required_fields.md
@@ -361,7 +361,9 @@ _There are no required properties in schema Growth conditions_
 ### Medical tests<a name='Medical tests'></a>
 _There are no required properties in schema Medical tests_
 ### Collection institute<a name='Collection institute'></a>
-_There are no required properties in schema Collection institute_
+Property name | Description | Type | Object reference? | User friendly name | Allowed values | Example 
+--- | --- | --- | --- | --- | --- | --- 
+name | The name of the collection institute. | string |  | Collection institute name |  | institute_1; Addenbrooke's Hospital; University of California, San Francisco
 ### Disease profile<a name='Disease profile'></a>
 _There are no required properties in schema Disease profile_
 ### Preservation and storage<a name='Preservation and storage'></a>

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -355,7 +355,7 @@ adjacent_diseases | Short description of the disease(s) adjacent to the specimen
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03
-collection_site | Institute where the biomaterial was collected on. | string | no |  | Collection site |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
+collection_institute | Institute where the biomaterial was collected on. | string | no |  | Collection institute |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
 purchased_specimen | Information about a purchased specimen. | object | no | [See module  purchased_reagents](module.md#purchased-reagents) | Purchased specimen |  | 
 
 ## Cell suspension

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -355,6 +355,7 @@ adjacent_diseases | Short description of the disease(s) adjacent to the specimen
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03
+collection_site | Where the biomaterial was collected on. | string | no |  | Collection site |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
 purchased_specimen | Information about a purchased specimen. | object | no | [See module  purchased_reagents](module.md#purchased-reagents) | Purchased specimen |  | 
 
 ## Cell suspension

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -355,7 +355,7 @@ adjacent_diseases | Short description of the disease(s) adjacent to the specimen
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03
-collection_site | Where the biomaterial was collected on. | string | no |  | Collection site |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
+collection_site | Institute where the biomaterial was collected on. | string | no |  | Collection site |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
 purchased_specimen | Information about a purchased specimen. | object | no | [See module  purchased_reagents](module.md#purchased-reagents) | Purchased specimen |  | 
 
 ## Cell suspension

--- a/docs/jsonBrowser/type.md
+++ b/docs/jsonBrowser/type.md
@@ -355,7 +355,7 @@ adjacent_diseases | Short description of the disease(s) adjacent to the specimen
 state_of_specimen | State of the specimen at the time of collection. | object | no | [See module  state_of_specimen](module.md#state-of-specimen) | State of specimen |  | 
 preservation_storage | Information about how a specimen was preserved and/or stored over a period of time. | object | no | [See module  preservation_storage](module.md#preservation-storage) | Preservation/Storage |  | 
 collection_time | When the biomaterial was collected. | string | no |  | Time of collection |  | 2016-01-21T00:00:00Z; 2016-03
-collection_institute | Institute where the biomaterial was collected on. | string | no |  | Collection institute |  | 52.175013, 0.141645; site_1; Addenbrooke's Hospital
+collection_institute | Institute where the biomaterial was collected on. | object | no | [See module  organ_ontology](module.md#organ-ontology) | Collection institute |  | 
 purchased_specimen | Information about a purchased specimen. | object | no | [See module  purchased_reagents](module.md#purchased-reagents) | Purchased specimen |  | 
 
 ## Cell suspension

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -2,7 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Information about collection institute location.",
     "additionalProperties": false,
-    "minProperties": 1,
+    "required": [
+      "name"
+      ],
     "dependencies": {
       "latitude": [
         "longitude"
@@ -26,6 +28,13 @@
           "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
           "example": "4.6.1"
         },
+        "name": {
+          "description": "The name of the collection institute.",
+          "type": "string",
+          "example": "institute_1; Addenbrooke's Hospital; University of California, San Francisco",
+          "user_friendly": "Collection institute name",
+          "guidelines": "Use pseudonymized name if the institute name is unknown or is considered sensitive information."
+        },
         "latitude": {
           "description": "The latitute of the collection institute, in decimal degrees.",
           "type": "string",
@@ -41,13 +50,6 @@
           "example": "0.1; -84.512016; 23.792138",
           "user_friendly": "Collection institute longitude",
           "guidelines": "If the exact location is considered sensitive information, use one decimal place."
-        },
-        "name": {
-          "description": "The name of the collection institute.",
-          "type": "string",
-          "example": "University of California, San Francisco",
-          "user_friendly": "Collection institute name",
-          "guidelines": "Use pseudonymized name of the institute to keep the location private."
         }
     }
 }

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -31,7 +31,7 @@
           "pattern": "^-?([0-8]?\\d|90)(\\.\\d{1,6})?$",
           "example": "52.1; -0.127541; 38.045956",
           "user_friendly": "Collection institute latitude",
-          "guidelines": "Use one decimal place to keep the exact location private."
+          "guidelines": "If the exact location is considered sensitive information, use one decimal place."
         },
         "longitude": {
           "description": "The longitude of the collection institute, in decimal degrees.",
@@ -39,7 +39,7 @@
           "pattern": "^-?((1?[0-7]?\\d)|180)(\\.\\d{1,6})?$",
           "example": "0.1; -84.512016; 23.792138",
           "user_friendly": "Collection institute longitude",
-          "guidelines": "Use one decimal place to keep the exact location private."
+          "guidelines": "If the exact location is considered sensitive information, use one decimal place."
         },
         "name": {
           "description": "The name of the collection institute.",

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Information about collection institute location.",
     "additionalProperties": false,
+    "minProperties": 1,
     "dependencies": {
       "latitude": [
         "longitude"

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -46,7 +46,7 @@
         "longitude": {
           "description": "Longitude of the collection institute, in decimal degrees.",
           "type": "string",
-          "pattern": "^-?((1?[0-7]?\\d)|180)(\\.\\d{1,6})?$",
+          "pattern": "^-?((1?[0-7]?\\d)|180)\\.(\\d{0,5}[1-9]|0)$",
           "example": "0.1; -84.512016; 23.792138",
           "user_friendly": "Collection institute longitude",
           "guidelines": "Use one decimal place if the exact location is considered sensitive information."

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Information about collection institute location.",
+    "additionalProperties": false,
+    "title": "Collection institute",
+    "name": "collection_institute",
+    "type": "object",
+    "properties": {
+        "describedBy": {
+          "description": "The URL reference to the schema.",
+          "type": "string",
+          "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/module/biomaterial/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/familial_relationship"
+        },
+        "schema_version": {
+          "description": "The version number of the schema in major.minor.patch format.",
+          "type": "string",
+          "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+          "example": "4.6.1"
+        },
+        "latitude": {
+          "description": "The latitute of the collection institute, in decimal degrees.",
+          "type": "string",
+          "pattern": "^-?([0-8]?\\d|90)(\\.\\d{1,6})?$",
+          "example": "52.1; -0.127541; 38.045956",
+          "user_friendly": "Collection institute latitude",
+          "guidelines": "Use one decimal place to keep the exact location private."
+        },
+        "longitude": {
+          "description": "The longitude of the collection institute, in decimal degrees.",
+          "type": "string",
+          "pattern": "^-?((1?[0-7]?\\d)|180)(\\.\\d{1,6})?$",
+          "example": "0.1; -84.512016; 23.792138",
+          "user_friendly": "Collection institute longitude",
+          "guidelines": "Use one decimal place to keep the exact location private."
+        },
+        "name": {
+          "description": "The name of the collection institute.",
+          "type": "string",
+          "example": "University of California, San Francisco",
+          "user_friendly": "Collection institute name",
+          "guidelines": "Use pseudonymized name of the institute to keep the location private."
+        }
+    }
+}

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -29,7 +29,7 @@
           "example": "4.6.1"
         },
         "name": {
-          "description": "Name of the collection institute.",
+          "description": "Name of the institute where the biomaterial was collected on.",
           "type": "string",
           "minLength": 1,          
           "example": "institute_1; Addenbrooke's Hospital; University of California, San Francisco",
@@ -37,7 +37,7 @@
           "guidelines": "Use pseudonymized name if the institute name is unknown or is considered sensitive information."
         },
         "latitude": {
-          "description": "Latitute of the collection institute, in decimal degrees.",
+          "description": "Latitute of the institute where the biomaterial was collected on, in decimal degrees.",
           "type": "string",
           "pattern": "^-?([0-8]?\\d|90)\\.(\\d{0,5}[1-9]|0)$",
           "example": "52.1; -0.127541; 38.045956",
@@ -45,7 +45,7 @@
           "guidelines": "Use one decimal place if the exact location is considered sensitive information."
         },
         "longitude": {
-          "description": "Longitude of the collection institute, in decimal degrees.",
+          "description": "Longitude of the institute where the biomaterial was collected on, in decimal degrees.",
           "type": "string",
           "pattern": "^-?((1?[0-7]?\\d)|180)\\.(\\d{0,5}[1-9]|0)$",
           "example": "0.1; -84.512016; 23.792138",

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -2,6 +2,14 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Information about collection institute location.",
     "additionalProperties": false,
+    "dependencies": {
+      "latitude": [
+        "longitude"
+        ],
+      "longitude": [
+        "latitude"
+        ]          
+      },
     "title": "Collection institute",
     "name": "collection_institute",
     "type": "object",

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -29,27 +29,27 @@
           "example": "4.6.1"
         },
         "name": {
-          "description": "The name of the collection institute.",
+          "description": "Name of the collection institute.",
           "type": "string",
           "example": "institute_1; Addenbrooke's Hospital; University of California, San Francisco",
           "user_friendly": "Collection institute name",
           "guidelines": "Use pseudonymized name if the institute name is unknown or is considered sensitive information."
         },
         "latitude": {
-          "description": "The latitute of the collection institute, in decimal degrees.",
+          "description": "Latitute of the collection institute, in decimal degrees.",
           "type": "string",
           "pattern": "^-?([0-8]?\\d|90)(\\.\\d{1,6})?$",
           "example": "52.1; -0.127541; 38.045956",
           "user_friendly": "Collection institute latitude",
-          "guidelines": "If the exact location is considered sensitive information, use one decimal place."
+          "guidelines": "Use one decimal place if the exact location is considered sensitive information."
         },
         "longitude": {
-          "description": "The longitude of the collection institute, in decimal degrees.",
+          "description": "Longitude of the collection institute, in decimal degrees.",
           "type": "string",
           "pattern": "^-?((1?[0-7]?\\d)|180)(\\.\\d{1,6})?$",
           "example": "0.1; -84.512016; 23.792138",
           "user_friendly": "Collection institute longitude",
-          "guidelines": "If the exact location is considered sensitive information, use one decimal place."
+          "guidelines": "Use one decimal place if the exact location is considered sensitive information."
         }
     }
 }

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -31,6 +31,7 @@
         "name": {
           "description": "Name of the collection institute.",
           "type": "string",
+          "minLength": 1,          
           "example": "institute_1; Addenbrooke's Hospital; University of California, San Francisco",
           "user_friendly": "Collection institute name",
           "guidelines": "Use pseudonymized name if the institute name is unknown or is considered sensitive information."

--- a/json_schema/module/biomaterial/collection_institute.json
+++ b/json_schema/module/biomaterial/collection_institute.json
@@ -38,7 +38,7 @@
         "latitude": {
           "description": "Latitute of the collection institute, in decimal degrees.",
           "type": "string",
-          "pattern": "^-?([0-8]?\\d|90)(\\.\\d{1,6})?$",
+          "pattern": "^-?([0-8]?\\d|90)\\.(\\d{0,5}[1-9]|0)$",
           "example": "52.1; -0.127541; 38.045956",
           "user_friendly": "Collection institute latitude",
           "guidelines": "Use one decimal place if the exact location is considered sensitive information."

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -118,11 +118,11 @@
               ]
         },
         "collection_site": {
-            "description": "Where the biomaterial was collected on.",
+            "description": "Institute where the biomaterial was collected on.",
             "type": "string", 
             "user_friendly": "Collection site", 
             "example": "52.175013, 0.141645; site_1; Addenbrooke's Hospital",
-            "guidelines": "Enter collection site latitude longitude in decimal degrees. If decimal degrees not available use site name or pseudonymised site name."
+            "guidelines": "Enter collection site latitude longitude in decimal degrees. If decimal degrees not available use site name or pseudonymized site name."
         },
         "purchased_specimen": {
             "description": "Information about a purchased specimen.",

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -122,7 +122,7 @@
             "type": "string", 
             "user_friendly": "Collection site", 
             "example": "52.175013, 0.141645; site_1; Addenbrooke's Hospital",
-            "guidelines": "Enter collection site latitude longitude in deciman degrees. If decimal degrees not available use site name or pseudonymised site name."
+            "guidelines": "Enter collection site latitude longitude in decimal degrees. If decimal degrees not available use site name or pseudonymised site name."
         },
         "purchased_specimen": {
             "description": "Information about a purchased specimen.",

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -119,10 +119,9 @@
         },
         "collection_institute": {
             "description": "Institute where the biomaterial was collected on.",
-            "type": "string", 
-            "user_friendly": "Collection institute", 
-            "example": "52.175013, 0.141645; site_1; Addenbrooke's Hospital",
-            "guidelines": "Enter collection institute latitude longitude in decimal degrees. If decimal degrees not available use institute name or pseudonymized institute name."
+            "type": "object", 
+            "$ref": "module/ontology/organ_ontology.json",
+            "user_friendly": "Collection institute"
         },
         "purchased_specimen": {
             "description": "Information about a purchased specimen.",

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -117,12 +117,12 @@
                  }
               ]
         },
-        "collection_site": {
+        "collection_institute": {
             "description": "Institute where the biomaterial was collected on.",
             "type": "string", 
-            "user_friendly": "Collection site", 
+            "user_friendly": "Collection institute", 
             "example": "52.175013, 0.141645; site_1; Addenbrooke's Hospital",
-            "guidelines": "Enter collection site latitude longitude in decimal degrees. If decimal degrees not available use site name or pseudonymized site name."
+            "guidelines": "Enter collection institute latitude longitude in decimal degrees. If decimal degrees not available use institute name or pseudonymized institute name."
         },
         "purchased_specimen": {
             "description": "Information about a purchased specimen.",

--- a/json_schema/type/biomaterial/specimen_from_organism.json
+++ b/json_schema/type/biomaterial/specimen_from_organism.json
@@ -117,6 +117,13 @@
                  }
               ]
         },
+        "collection_site": {
+            "description": "Where the biomaterial was collected on.",
+            "type": "string", 
+            "user_friendly": "Collection site", 
+            "example": "52.175013, 0.141645; site_1; Addenbrooke's Hospital",
+            "guidelines": "Enter collection site latitude longitude in deciman degrees. If decimal degrees not available use site name or pseudonymised site name."
+        },
         "purchased_specimen": {
             "description": "Information about a purchased specimen.",
             "type": "object",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,3 +1,1 @@
 Schema,Change type,Change message,Version,Date
-module/biomaterial/collection_institute,major,"Added collection_institute module.Issue1606",,
-type/biomaterial/specimen_from_organism,minor,"Added optional collection_institute in specimen_from_organism.Issue1606",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,3 @@
 Schema,Change type,Change message,Version,Date
-type/biomaterial/specimen_from_organism,minor,"Added collection site in specimen_from_organism.Issue1606",,
+module/biomaterial/collection_institute,major,"Added collection_institute module.Issue1606",,
+type/biomaterial/specimen_from_organism,minor,"Added optional collection_institute in specimen_from_organism.Issue1606",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,2 +1,2 @@
 Schema,Change type,Change message,Version,Date
-type/biomaterial/specimen_from_organism.json,minor,"Added collection site in specimen_from_organism.Issue1606",,
+type/biomaterial/specimen_from_organism,minor,"Added collection site in specimen_from_organism.Issue1606",,

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+type/biomaterial/specimen_from_organism.json,minor,"Added collection site in specimen_from_organism.Issue1606",,

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -21,6 +21,7 @@
         "module": {
             "biomaterial": {
                 "cell_morphology": "6.1.7",
+                "collection_institute": "0.0.0",
                 "death": "5.5.1",
                 "disease_profile": "1.0.0",
                 "familial_relationship": "6.0.3",

--- a/json_schema/versions.json
+++ b/json_schema/versions.json
@@ -1,5 +1,5 @@
 {
-    "last_update_date": "2025-02-28T10:45:54Z",
+    "last_update_date": "2025-03-24T17:43:39Z",
     "version_numbers": {
         "core": {
             "biomaterial": {
@@ -21,7 +21,7 @@
         "module": {
             "biomaterial": {
                 "cell_morphology": "6.1.7",
-                "collection_institute": "0.0.0",
+                "collection_institute": "1.0.0",
                 "death": "5.5.1",
                 "disease_profile": "1.0.0",
                 "familial_relationship": "6.0.3",
@@ -99,7 +99,7 @@
                 "donor_organism": "18.0.0",
                 "imaged_specimen": "3.5.0",
                 "organoid": "11.5.0",
-                "specimen_from_organism": "10.9.0"
+                "specimen_from_organism": "10.10.0"
             },
             "file": {
                 "analysis_file": "8.0.0",


### PR DESCRIPTION
### Release notes
#1606 

For `specimen_from_organism.json` schema:
- Field name: `collection_site`
- Field description: Institute where the biomaterial was collected on.
- Field type: string
- Required: no
- Guidelines: Enter collection site latitude longitude in decimal degrees. If decimal degrees not available use site name or pseudonymized site name.
 
### Reviews requested

- Need 4 Reviewers to approve because this is a **major** update
