### PR TITLE
Changed body_mass_index type to allow ranges Fixes#1624

### DIFF
--- a/docs/jsonBrowser/module.md
+++ b/docs/jsonBrowser/module.md
@@ -430,7 +430,7 @@ Location: module/biomaterial/human_specific.json
 
 Property name | Description | Type | Required? | Object reference? | User friendly name | Allowed values | Example 
 --- | --- | --- | --- | --- | --- | --- | --- 
-body_mass_index | The body mass index of the donor. | number | no |  | Body mass index |  | 36.4
+body_mass_index | The body mass index of the donor. | string | no |  | Body mass index |  | 20.21; 27.5-32.5
 ethnicity | Ethnicity of the donor. | array | no | [See module  ethnicity_ontology](module.md#ethnicity-ontology) | Ethnicity |  | 
 
 ## Growth conditions<a name='Growth conditions'></a>

--- a/json_schema/module/biomaterial/human_specific.json
+++ b/json_schema/module/biomaterial/human_specific.json
@@ -20,7 +20,7 @@
         "body_mass_index": {
             "description": "The body mass index of the donor.",
             "type": "string",
-            "pattern": "^[0-6]?[0-9](\\.[0-9]+)?(-[0-6]?[0-9]\\.?[0-9]*)?$",
+            "pattern": "^[0-1]?[0-9]{1,2}(\\.[0-9]+)?(-[0-1]?[0-9]{1,2}(\\.[0-9]+)?)?$",
             "example": "20.21; 27.5-32.5",
             "user_friendly": "Body mass index",
             "guidelines": "Enter either a single value or a range of values. Indicate a range using a hyphen."

--- a/json_schema/module/biomaterial/human_specific.json
+++ b/json_schema/module/biomaterial/human_specific.json
@@ -19,11 +19,11 @@
         },
         "body_mass_index": {
             "description": "The body mass index of the donor.",
-            "type": "number",
-            "maximum": 100,
-            "minimum": 5,
-            "example": 36.4,
-            "user_friendly": "Body mass index"
+            "type": "string",
+            "pattern": "^[0-6]?[0-9](\\.[0-9]+)?(-[0-6]?[0-9]\\.?[0-9]*)?$",
+            "example": "20.21; 27.5-32.5",
+            "user_friendly": "Body mass index",
+            "guidelines": "Enter either a single value or a range of values. Indicate a range using a hyphen."
         },
         "ethnicity": {
             "description": "Ethnicity of the donor.",

--- a/json_schema/update_log.csv
+++ b/json_schema/update_log.csv
@@ -1,1 +1,2 @@
 Schema,Change type,Change message,Version,Date
+module/biomaterial/human_specific,major,Changed bmi pattern type to allow ranges,,


### PR DESCRIPTION
### Release notes

For `human_specific.json` schema:
- Change the `body_mass_index` type to `string` to allow ranges
 

### Reviews requested

- Need 4 Reviewers to approve because this is a **major** update
