### PR TITLE
fix(schemas): autofix linting issues of biomaterial_core.json

### DIFF
--- a/json_schema/core/biomaterial/biomaterial_core.json
+++ b/json_schema/core/biomaterial/biomaterial_core.json
@@ -1,94 +1,88 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Information about any biological material that was generated/used in the project including everything from a whole organism to subcellular components.",
-    "additionalProperties": false,
-    "required": [
-        "biomaterial_id",
-        "ncbi_taxon_id"
-    ],
-    "title": "Biomaterial core",
-    "name": "biomaterial_core",
-    "type": "object",
-    "properties": {
-        "describedBy": {
-            "description": "The URL reference to the schema.",
-            "type": "string",
-            "pattern" : "^(http|https)://schema.(.*?)humancellatlas.org/core/biomaterial/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/biomaterial_core"
-        },
-        "schema_version": {
-            "description": "The version number of the schema in major.minor.patch format.",
-            "type": "string",
-            "pattern": "^\\d+\\.\\d+\\.\\d+$",
-            "example": "4.6.1"
-        },
-        "biomaterial_id":{
-            "description": "A unique ID for the biomaterial.",
-            "type": "string",
-            "user_friendly": "Biomaterial ID"
-        },
-        "biomaterial_name": {
-            "description": "A short, descriptive name for the biomaterial that need not be unique.",
-            "type": "string",
-            "user_friendly": "Biomaterial name"
-        },
-        "biomaterial_description": {
-            "description": "A general description of the biomaterial.",
-            "type": "string",
-            "user_friendly": "Biomaterial description"
-        },
-        "ncbi_taxon_id" : {
-            "description": "A taxonomy ID (taxonID) from NCBI.",
-            "type" : "array",
-            "items":{
-                "type": "integer"
-            },
-            "user_friendly": "NCBI taxon ID",
-            "example": 9606
-        },
-        "genotype": {
-            "description": "Genotype of the biomaterial.",
-            "type": "string",
-            "user_friendly": "Genotype",
-            "example": "DRB1 0401 protective allele; HLA-B*3901 allele"
-        },
-        "supplementary_files": {
-            "description": "A list of filenames of biomaterial-level supplementary files.",
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "user_friendly": "Supplementary files",
-            "example": "sample_site_image.jpg"
-        },
-        "biosamples_accession": {
-            "description": "A BioSamples accession.",
-            "type": "string",
-            "pattern": "^SAM(D|N|E([AG]?))[0-9]+$",
-            "user_friendly": "BioSamples accession",
-            "example": "SAMN00000000",
-            "guidelines": "Enter accession if sample has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with SAMD, SAMN, or SAME, respectively."
-        },
-        "insdc_sample_accession": {
-            "description": "An International Nucleotide Sequence Database Collaboration (INSDC) sample accession.",
-            "type": "string",
-            "pattern": "^[DES]RS[0-9]+$",
-            "user_friendly": "INSDC sample accession",
-            "example": "SRS0000000",
-            "guidelines": "Enter accession if sample has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with DRS, SRS, or ERS, respecitvely."
-        },
-        "HDBR_accession": {
-            "description": "A Human Developmental Biology Resource (HDBR) sample accession.",
-            "type": "string",
-            "pattern": "(^[0-9]{5})(,\\s[0-9]{1,},\\s[a-zA-Z]+$){0,1}",
-            "user_friendly": "HDBR accession",
-            "example": "34526; 14758, 2, liver",
-            "guidelines": "Enter accession if sample has been obtained from the Human Developmental Biology Resource (HDBR)."
-        },
-        "timecourse": {
-            "description": "Information relating to a timecourse associated with this biomaterial.",
-            "type": "object",
-            "$ref": "module/biomaterial/timecourse.json",
-            "user_friendly": "Timecourse"
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Information about any biological material that was generated/used in the project including everything from a whole organism to subcellular components.",
+  "additionalProperties": false,
+  "required": [ "biomaterial_id", "ncbi_taxon_id" ],
+  "title": "Biomaterial core",
+  "x-name": "biomaterial_core",
+  "type": "object",
+  "properties": {
+    "describedBy": {
+      "description": "The URL reference to the schema.",
+      "type": "string",
+      "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/core/biomaterial/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/biomaterial_core"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "x-example": "4.6.1"
+    },
+    "biomaterial_id": {
+      "description": "A unique ID for the biomaterial.",
+      "type": "string",
+      "x-user_friendly": "Biomaterial ID"
+    },
+    "biomaterial_name": {
+      "description": "A short, descriptive name for the biomaterial that need not be unique.",
+      "type": "string",
+      "x-user_friendly": "Biomaterial name"
+    },
+    "biomaterial_description": {
+      "description": "A general description of the biomaterial.",
+      "type": "string",
+      "x-user_friendly": "Biomaterial description"
+    },
+    "ncbi_taxon_id": {
+      "description": "A taxonomy ID (taxonID) from NCBI.",
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "x-user_friendly": "NCBI taxon ID",
+      "x-example": 9606
+    },
+    "genotype": {
+      "description": "Genotype of the biomaterial.",
+      "type": "string",
+      "x-user_friendly": "Genotype",
+      "x-example": "DRB1 0401 protective allele; HLA-B*3901 allele"
+    },
+    "supplementary_files": {
+      "description": "A list of filenames of biomaterial-level supplementary files.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "x-user_friendly": "Supplementary files",
+      "x-example": "sample_site_image.jpg"
+    },
+    "biosamples_accession": {
+      "description": "A BioSamples accession.",
+      "type": "string",
+      "pattern": "^SAM(D|N|E([AG]?))[0-9]+$",
+      "x-user_friendly": "BioSamples accession",
+      "x-example": "SAMN00000000",
+      "x-guidelines": "Enter accession if sample has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with SAMD, SAMN, or SAME, respectively."
+    },
+    "insdc_sample_accession": {
+      "description": "An International Nucleotide Sequence Database Collaboration (INSDC) sample accession.",
+      "type": "string",
+      "pattern": "^[DES]RS[0-9]+$",
+      "x-user_friendly": "INSDC sample accession",
+      "x-example": "SRS0000000",
+      "x-guidelines": "Enter accession if sample has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with DRS, SRS, or ERS, respecitvely."
+    },
+    "HDBR_accession": {
+      "description": "A Human Developmental Biology Resource (HDBR) sample accession.",
+      "type": "string",
+      "pattern": "(^[0-9]{5})(,\\s[0-9]{1,},\\s[a-zA-Z]+$){0,1}",
+      "x-user_friendly": "HDBR accession",
+      "x-example": "34526; 14758, 2, liver",
+      "x-guidelines": "Enter accession if sample has been obtained from the Human Developmental Biology Resource (HDBR)."
+    },
+    "timecourse": {
+      "$ref": "module/biomaterial/timecourse.json"
     }
+  }
 }


### PR DESCRIPTION
<!-- Please provide a meaningful title for the PR. -->

<!-- If this PR updates the metadata schema:
1. Include "Fixes #<issue number>" in the PR title.
2. Include summary of each change, grouped by schema, under "Release notes".
3. Indicate how many Reviewers are requested to approve PR before merging, why, and when the PR should be merged. -->
Fixes #1626 

### Release notes

For `biomaterial_core.json` schema:
- Fixed issues with unknown keywords that don't have an `x-` prefix to ensure compatibility with future versions of JSON Schema.
- Resolved `$ref` sibling keyword evaluation issue in Draft 7 and older dialects.

Before and after:

<img width="1168" height="718" alt="image" src="https://github.com/user-attachments/assets/5f4bd15d-7f5a-4a6c-9a64-1099c18c013a" />

### Reviews requested

- Need 1-2 Reviewers to approve because this is a minor update.

### Note

For context, I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. We have recently added many rules `prefixing unknown keywords with x-` which will be introduced in the newer JSON Schema drafts
If beneficial to the project, I suggest integrating the complete cli with it to write the best schemas and catch any errors and follow best practices. Example of  an integration - https://github.com/krakend/krakend-schema/blob/main/.github/workflows/validate-json-schema.yml#L10